### PR TITLE
docs: update README and CHANGELOG for Phase 2 completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-12-06
+
+### Added
+- **Desktop App** - Native desktop application built with Wails v2
+  - Cross-platform support (macOS, Windows, Linux)
+  - Vault creation with master password validation
+  - Vault unlock with password authentication
+  - Secrets list view with metadata display
+  - Password visibility toggle
+  - Modern React + TypeScript + Tailwind CSS frontend
+  - Playwright E2E test framework
+
+### Changed
+- Reorganized project structure with `desktop/` directory for Wails app
+
 ## [0.3.0] - 2025-12-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Managing secrets shouldn't require a PhD in DevOps. secretctl is a local-first s
 - **Just works** — Single binary, no servers, no configuration files
 - **Stays local** — Your secrets never leave your machine
 - **Plays nice with AI** — Designed for the age of AI coding assistants (MCP-ready)
-- **Respects your workflow** — CLI-first with optional Web UI
+- **Respects your workflow** — CLI-first with Desktop App
 
 ```
 # That's it. You're done.
@@ -214,6 +214,32 @@ allowed_commands:
 ```
 
 > **Security**: AI agents never receive plaintext secrets. The `secret_run` tool injects secrets as environment variables, and output is automatically sanitized.
+
+### Desktop App
+
+secretctl includes a native desktop application built with Wails v2:
+
+```bash
+# Build the desktop app
+cd desktop && wails build
+
+# Or run in development mode
+cd desktop && wails dev
+```
+
+**Features:**
+- Native macOS/Windows/Linux application
+- Create and unlock vaults with master password
+- View secrets list with metadata
+- Password visibility toggle
+- Modern React + TypeScript frontend
+
+**Development:**
+```bash
+# Run E2E tests (Playwright)
+cd desktop/frontend
+npm run test:e2e
+```
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Add Desktop App section to README documenting Wails v2 features
- Add v0.4.0 changelog entry for Desktop App release
- Update project description (CLI-first with Desktop App)

## Changes

### README.md
- Added Desktop App section with build/dev instructions
- Listed features: cross-platform, vault management, Playwright E2E tests
- Updated description from "Web UI" to "Desktop App"

### CHANGELOG.md
- Added v0.4.0 release notes
- Documented Desktop App features and tech stack

## Test plan
- [x] Verify README renders correctly
- [x] Verify CHANGELOG format follows Keep a Changelog