### PR TITLE
docs: update README and CHANGELOG for Desktop App CRUD features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-12-08
+
+### Added
+- **Desktop App Secret CRUD** - Full secret management in desktop application
+  - Create secrets with key, value, URL, tags, and notes
+  - Read and view secret details with metadata
+  - Update existing secrets
+  - Delete secrets with confirmation dialog
+  - Search and filter secrets by key
+  - Copy secret values to clipboard with auto-clear feedback
+- **E2E Test Coverage** - All E2E tests enabled and passing
+  - 6 authentication tests (SEC-001, SEC-002)
+  - 6 secret CRUD tests (CORE-001 to CORE-006)
+
+### Fixed
+- Playwright strict mode violations in E2E tests
+- Dialog handling in delete confirmation tests
+
 ## [0.4.0] - 2025-12-06
 
 ### Added
@@ -16,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vault unlock with password authentication
   - Secrets list view with metadata display
   - Password visibility toggle
+  - Auto-lock on idle timeout (15 minutes)
   - Modern React + TypeScript + Tailwind CSS frontend
   - Playwright E2E test framework
 

--- a/README.md
+++ b/README.md
@@ -230,15 +230,25 @@ cd desktop && wails dev
 **Features:**
 - Native macOS/Windows/Linux application
 - Create and unlock vaults with master password
-- View secrets list with metadata
+- Full secret CRUD operations (Create, Read, Update, Delete)
+- Search and filter secrets by key
+- Copy secret values to clipboard (with auto-clear)
+- Metadata support (URL, tags, notes)
 - Password visibility toggle
-- Modern React + TypeScript frontend
+- Auto-lock on idle timeout
+- Modern React + TypeScript + Tailwind CSS frontend
 
 **Development:**
 ```bash
 # Run E2E tests (Playwright)
 cd desktop/frontend
 npm run test:e2e
+
+# Run with visible browser
+npm run test:e2e:headed
+
+# Run with Playwright UI
+npm run test:e2e:ui
 ```
 
 ## Security


### PR DESCRIPTION
## Summary
- Update README Desktop App section with full CRUD features documentation
- Add v0.4.1 to CHANGELOG with Secret CRUD UI and E2E test completion
- Document additional E2E test commands for development

## Changes
- **README.md**: Enhanced Desktop App features list
  - Full CRUD operations
  - Search and filter
  - Clipboard support with auto-clear
  - Metadata support (URL, tags, notes)
  - Auto-lock on idle timeout
  - Additional E2E test commands
- **CHANGELOG.md**: New v0.4.1 release notes
  - Desktop App Secret CRUD features
  - E2E test coverage completion
  - Bug fixes for Playwright tests

## Test Plan
- [x] Documentation review
- [x] CODEX review completed

Closes #20