### PR TITLE
feat(desktop): enhance Secret CRUD with keyboard shortcuts and toasts

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { AuthPage } from '@/pages/AuthPage'
 import { SecretsPage } from '@/pages/SecretsPage'
 import { AuditPage } from '@/pages/AuditPage'
+import { ToastProvider } from '@/hooks/useToast'
 import { GetAuthStatus } from '../wailsjs/go/main/App'
 
 type Page = 'secrets' | 'audit'
@@ -32,18 +33,28 @@ function App() {
   }
 
   if (!isAuthenticated) {
-    return <AuthPage onAuthenticated={() => setIsAuthenticated(true)} />
+    return (
+      <ToastProvider>
+        <AuthPage onAuthenticated={() => setIsAuthenticated(true)} />
+      </ToastProvider>
+    )
   }
 
   if (currentPage === 'audit') {
-    return <AuditPage onNavigateBack={() => setCurrentPage('secrets')} />
+    return (
+      <ToastProvider>
+        <AuditPage onNavigateBack={() => setCurrentPage('secrets')} />
+      </ToastProvider>
+    )
   }
 
   return (
-    <SecretsPage
-      onLocked={() => setIsAuthenticated(false)}
-      onNavigateToAudit={() => setCurrentPage('audit')}
-    />
+    <ToastProvider>
+      <SecretsPage
+        onLocked={() => setIsAuthenticated(false)}
+        onNavigateToAudit={() => setCurrentPage('audit')}
+      />
+    </ToastProvider>
   )
 }
 

--- a/desktop/frontend/src/components/ConfirmDialog.tsx
+++ b/desktop/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'default' | 'destructive'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  // Handle escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!open) return
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        onConfirm()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onConfirm, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onCancel}
+      data-testid="confirm-dialog"
+    >
+      <Card
+        className="w-full max-w-md mx-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {variant === 'destructive' && (
+              <AlertTriangle className="w-5 h-5 text-destructive" />
+            )}
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{message}</p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={onCancel}
+              data-testid="confirm-dialog-cancel"
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={variant === 'destructive' ? 'destructive' : 'default'}
+              onClick={onConfirm}
+              data-testid="confirm-dialog-confirm"
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/desktop/frontend/src/hooks/useToast.tsx
+++ b/desktop/frontend/src/hooks/useToast.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { CheckCircle, XCircle, AlertCircle, X } from 'lucide-react'
+
+interface Toast {
+  id: number
+  message: string
+  type: 'success' | 'error' | 'info'
+}
+
+interface ToastContextValue {
+  toast: (message: string, type?: Toast['type']) => void
+  success: (message: string) => void
+  error: (message: string) => void
+  info: (message: string) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+let toastId = 0
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const removeToast = useCallback((id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const addToast = useCallback((message: string, type: Toast['type'] = 'info') => {
+    const id = ++toastId
+    setToasts(prev => [...prev, { id, message, type }])
+    setTimeout(() => removeToast(id), 3000)
+  }, [removeToast])
+
+  const value: ToastContextValue = {
+    toast: addToast,
+    success: (message) => addToast(message, 'success'),
+    error: (message) => addToast(message, 'error'),
+    info: (message) => addToast(message, 'info'),
+  }
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map(t => (
+          <div
+            key={t.id}
+            className={`flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg animate-in slide-in-from-right-5 ${
+              t.type === 'success' ? 'bg-green-600 text-white' :
+              t.type === 'error' ? 'bg-red-600 text-white' :
+              'bg-zinc-800 text-white'
+            }`}
+            data-testid="toast"
+          >
+            {t.type === 'success' && <CheckCircle className="w-4 h-4" />}
+            {t.type === 'error' && <XCircle className="w-4 h-4" />}
+            {t.type === 'info' && <AlertCircle className="w-4 h-4" />}
+            <span className="text-sm">{t.message}</span>
+            <button
+              onClick={() => removeToast(t.id)}
+              className="ml-2 hover:opacity-70"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts for common operations (⌘N, ⌘L, ⌘F, ⌘C, ⌘S, Escape)
- Implement toast notification system for user feedback
- Replace browser confirm dialog with custom ConfirmDialog component
- Add form validation for required fields

## Changes
- `desktop/frontend/src/hooks/useToast.tsx`: New toast hook and provider
- `desktop/frontend/src/components/ConfirmDialog.tsx`: Custom confirmation dialog
- `desktop/frontend/src/pages/SecretsPage.tsx`: Keyboard shortcuts, toast integration, improved UX
- `desktop/frontend/src/App.tsx`: ToastProvider integration

## Test plan
- [x] TypeScript type check passes
- [x] Frontend build succeeds
- [x] Wails desktop app build succeeds
- [x] Go tests pass

Closes #43