### PR TITLE
docs: update README and CONTRIBUTING with documentation site links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ This is a security-focused project. Please:
 
 ## Getting Help
 
+- 📚 Read the [Documentation](https://forest6511.github.io/secretctl/)
 - Open a [discussion](https://github.com/forest6511/secretctl/discussions) for questions
 - Check existing issues and documentation first
 - Be patient and respectful when asking for help

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ No infrastructure. No subscription. No complexity.
 
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-website-blue)](https://forest6511.github.io/secretctl/)
 
 ---
 
@@ -273,7 +274,12 @@ For reporting security vulnerabilities, please see [SECURITY.md](SECURITY.md).
 
 ## Documentation
 
-- [MCP Server Guide](docs/mcp-server.md) - Detailed MCP integration documentation
+📚 **[Full Documentation](https://forest6511.github.io/secretctl/)** — Getting started, guides, and reference
+
+- [Getting Started](https://forest6511.github.io/secretctl/docs/getting-started/) - Installation and quick start
+- [CLI Guide](https://forest6511.github.io/secretctl/docs/guides/cli/) - Command-line usage
+- [MCP Integration](https://forest6511.github.io/secretctl/docs/guides/mcp/) - AI agent integration
+- [Desktop App](https://forest6511.github.io/secretctl/docs/guides/desktop/) - Native application guide
 - [Contributing Guide](CONTRIBUTING.md)
 - [Security Policy](SECURITY.md)
 


### PR DESCRIPTION
## Summary

- Add documentation badge to README
- Update Documentation section with links to the new docs website
- Remove broken link to deleted `docs/mcp-server.md`
- Add documentation link to CONTRIBUTING.md

## Changes

### README.md
- Added `Documentation` badge linking to https://forest6511.github.io/secretctl/
- Updated Documentation section with structured links to:
  - Getting Started
  - CLI Guide
  - MCP Integration
  - Desktop App
- Removed reference to deleted `docs/mcp-server.md`

### CONTRIBUTING.md
- Added documentation link in "Getting Help" section

## Related

- Follows PR #47 (Docusaurus setup) and PR #48 (MCP docs migration)