### PR TITLE
docs: add comprehensive Reference documentation

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1,9 +1,450 @@
 ---
 title: CLI Commands
-description: Complete CLI command reference.
+description: Complete CLI command reference for secretctl.
 sidebar_position: 1
 ---
 
 # CLI Commands Reference
 
-Coming soon.
+Complete reference for all secretctl CLI commands.
+
+## Global Options
+
+```bash
+secretctl [command] --help    # Show help for any command
+```
+
+---
+
+## init
+
+Initialize a new secret vault.
+
+```bash
+secretctl init
+```
+
+Creates a new encrypted vault at `~/.secretctl/vault.db`. You will be prompted to set a master password (minimum 8 characters).
+
+**Example:**
+
+```bash
+$ secretctl init
+Enter master password: ********
+Confirm master password: ********
+Vault initialized successfully.
+```
+
+---
+
+## set
+
+Store a secret value from standard input.
+
+```bash
+secretctl set [key] [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--notes string` | Add notes to the secret |
+| `--tags string` | Comma-separated tags (e.g., `dev,api`) |
+| `--url string` | Add URL reference to the secret |
+| `--expires string` | Expiration duration (e.g., `30d`, `1y`) |
+
+**Examples:**
+
+```bash
+# Basic usage (prompts for value)
+echo "sk-your-api-key" | secretctl set OPENAI_API_KEY
+
+# With metadata
+echo "mypassword" | secretctl set DB_PASSWORD \
+  --notes="Production database" \
+  --tags="prod,db" \
+  --url="https://console.example.com"
+
+# With expiration
+echo "temp-token" | secretctl set TEMP_TOKEN --expires="30d"
+```
+
+---
+
+## get
+
+Retrieve a secret value.
+
+```bash
+secretctl get [key] [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--show-metadata` | Show metadata with the secret |
+
+**Examples:**
+
+```bash
+# Get secret value only
+secretctl get API_KEY
+
+# Get secret with metadata
+secretctl get API_KEY --show-metadata
+```
+
+---
+
+## delete
+
+Delete a secret from the vault.
+
+```bash
+secretctl delete [key]
+```
+
+**Example:**
+
+```bash
+secretctl delete OLD_API_KEY
+```
+
+---
+
+## list
+
+List all secret keys in the vault.
+
+```bash
+secretctl list [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--tag string` | Filter by tag |
+| `--expiring string` | Show secrets expiring within duration (e.g., `7d`) |
+
+**Examples:**
+
+```bash
+# List all secrets
+secretctl list
+
+# Filter by tag
+secretctl list --tag=prod
+
+# Show expiring secrets
+secretctl list --expiring=7d
+```
+
+---
+
+## run
+
+Execute a command with secrets injected as environment variables.
+
+```bash
+secretctl run [flags] -- command [args...]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-k, --key stringArray` | Secret keys to inject (glob pattern supported) |
+| `-t, --timeout duration` | Command timeout (default: `5m`) |
+| `--env string` | Environment alias (e.g., `dev`, `staging`, `prod`) |
+| `--env-prefix string` | Environment variable name prefix |
+| `--no-sanitize` | Disable output sanitization |
+| `--obfuscate-keys` | Obfuscate secret key names in error messages |
+
+**Environment Variable Naming:**
+
+Secret keys are transformed to environment variable names:
+
+- `/` is replaced with `_`
+- `-` is replaced with `_`
+- Names are converted to UPPERCASE
+
+| Secret Key | Environment Variable |
+|------------|---------------------|
+| `aws/access_key` | `AWS_ACCESS_KEY` |
+| `db-password` | `DB_PASSWORD` |
+| `api/prod/key` | `API_PROD_KEY` |
+
+**Examples:**
+
+```bash
+# Single secret
+secretctl run -k API_KEY -- curl -H "Authorization: Bearer $API_KEY" https://api.example.com
+
+# Multiple secrets
+secretctl run -k DB_HOST -k DB_USER -k DB_PASS -- psql
+
+# Wildcard pattern (matches single level)
+secretctl run -k "aws/*" -- aws s3 ls
+
+# With timeout
+secretctl run -k API_KEY --timeout=30s -- ./long-script.sh
+
+# With environment alias
+secretctl run --env=prod -k "db/*" -- ./deploy.sh
+
+# With prefix
+secretctl run -k API_KEY --env-prefix=APP_ -- ./app
+```
+
+**Output Sanitization:**
+
+By default, command output is scanned for secret values. Any matches are replaced with `[REDACTED:key]`.
+
+```bash
+# If DB_PASSWORD contains "secret123"
+$ secretctl run -k DB_PASSWORD -- echo "Password is $DB_PASSWORD"
+Password is [REDACTED:DB_PASSWORD]
+```
+
+---
+
+## export
+
+Export secrets to `.env` or JSON format.
+
+```bash
+secretctl export [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-k, --key strings` | Keys to export (glob pattern supported) |
+| `-f, --format string` | Output format: `env`, `json` (default: `env`) |
+| `-o, --output string` | Output file path (default: stdout) |
+| `--with-metadata` | Include metadata in JSON output |
+| `--force` | Overwrite existing file without confirmation |
+
+**Examples:**
+
+```bash
+# Export all secrets to stdout
+secretctl export
+
+# Export to .env file
+secretctl export -o .env
+
+# Export specific keys as JSON
+secretctl export -k "aws/*" -f json -o config.json
+
+# Export with metadata
+secretctl export -f json --with-metadata -o secrets.json
+
+# Pipe to another command
+secretctl export -f json | jq '.DB_HOST'
+```
+
+---
+
+## generate
+
+Generate cryptographically secure random passwords.
+
+```bash
+secretctl generate [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-l, --length int` | Password length (8-256, default: 24) |
+| `-n, --count int` | Number of passwords to generate (1-100, default: 1) |
+| `-c, --copy` | Copy first password to clipboard |
+| `--exclude string` | Characters to exclude |
+| `--no-uppercase` | Exclude uppercase letters |
+| `--no-lowercase` | Exclude lowercase letters |
+| `--no-numbers` | Exclude numbers |
+| `--no-symbols` | Exclude symbols |
+
+**Examples:**
+
+```bash
+# Generate default password (24 chars)
+secretctl generate
+
+# Generate 32-char password without symbols
+secretctl generate -l 32 --no-symbols
+
+# Generate 5 passwords
+secretctl generate -n 5
+
+# Generate and copy to clipboard
+secretctl generate -c
+
+# Exclude ambiguous characters
+secretctl generate --exclude "0O1lI"
+```
+
+---
+
+## audit
+
+Manage audit logs.
+
+### audit list
+
+List audit log entries.
+
+```bash
+secretctl audit list [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--limit int` | Maximum number of events to show (default: 100) |
+| `--since string` | Show events since duration (e.g., `24h`) |
+
+**Example:**
+
+```bash
+secretctl audit list --limit=50 --since=24h
+```
+
+### audit verify
+
+Verify audit log HMAC chain integrity.
+
+```bash
+secretctl audit verify
+```
+
+**Example:**
+
+```bash
+$ secretctl audit verify
+Audit log integrity verified. 1234 events checked.
+```
+
+### audit export
+
+Export audit logs to JSON or CSV format.
+
+```bash
+secretctl audit export [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--format string` | Output format: `json`, `csv` (default: `json`) |
+| `-o, --output string` | Output file path (default: stdout) |
+| `--since string` | Export events since duration (e.g., `30d`) |
+| `--until string` | Export events until date (RFC 3339) |
+
+**Example:**
+
+```bash
+secretctl audit export --format=csv -o audit.csv --since=30d
+```
+
+### audit prune
+
+Delete old audit log entries.
+
+```bash
+secretctl audit prune [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--older-than string` | Delete logs older than duration (e.g., `12m` for 12 months) |
+| `--dry-run` | Show what would be deleted without deleting |
+| `-f, --force` | Skip confirmation prompt |
+
+**Example:**
+
+```bash
+# Preview deletions
+secretctl audit prune --older-than=12m --dry-run
+
+# Delete with confirmation
+secretctl audit prune --older-than=12m
+
+# Delete without confirmation
+secretctl audit prune --older-than=12m --force
+```
+
+---
+
+## mcp-server
+
+Start the MCP server for AI coding assistant integration.
+
+```bash
+secretctl mcp-server
+```
+
+**Authentication:**
+
+Set `SECRETCTL_PASSWORD` environment variable before starting:
+
+```bash
+SECRETCTL_PASSWORD=your-password secretctl mcp-server
+```
+
+**Available MCP Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `secret_list` | List secret keys with metadata (no values) |
+| `secret_exists` | Check if a secret exists with metadata |
+| `secret_get_masked` | Get masked secret value (e.g., `****WXYZ`) |
+| `secret_run` | Execute command with secrets as environment variables |
+
+**Policy Configuration:**
+
+Create `~/.secretctl/mcp-policy.yaml` to configure allowed commands:
+
+```yaml
+version: 1
+default_action: deny
+allowed_commands:
+  - aws
+  - gcloud
+  - kubectl
+```
+
+See [MCP Integration Guide](/docs/guides/mcp/) for detailed configuration.
+
+---
+
+## completion
+
+Generate shell autocompletion scripts.
+
+```bash
+secretctl completion [bash|zsh|fish|powershell]
+```
+
+**Examples:**
+
+```bash
+# Bash
+secretctl completion bash > /etc/bash_completion.d/secretctl
+
+# Zsh
+secretctl completion zsh > "${fpath[1]}/_secretctl"
+
+# Fish
+secretctl completion fish > ~/.config/fish/completions/secretctl.fish
+```

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -1,9 +1,322 @@
 ---
 title: Configuration
-description: Configuration options and environment variables.
+description: Configuration options, environment variables, and file structure.
 sidebar_position: 3
 ---
 
 # Configuration Reference
 
-Coming soon.
+Complete reference for secretctl configuration options, environment variables, and file structure.
+
+## Environment Variables
+
+### Vault Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SECRETCTL_VAULT_DIR` | Directory containing the vault files | `~/.secretctl` |
+| `SECRETCTL_PASSWORD` | Master password for vault operations | (none) |
+
+**Usage Examples:**
+
+```bash
+# Use a custom vault directory
+export SECRETCTL_VAULT_DIR=/path/to/custom/vault
+secretctl list
+
+# Provide password via environment variable (non-interactive)
+SECRETCTL_PASSWORD=mypassword secretctl get API_KEY
+
+# MCP server uses SECRETCTL_PASSWORD for authentication
+SECRETCTL_PASSWORD=mypassword secretctl mcp-server
+```
+
+### Security Notes
+
+- `SECRETCTL_PASSWORD` is automatically cleared from the environment after reading
+- Avoid setting `SECRETCTL_PASSWORD` in shell profiles or persistent environment
+- For MCP server, use process-level environment variables in your MCP client configuration
+
+---
+
+## File Structure
+
+### Vault Directory
+
+The default vault directory is `~/.secretctl`. The structure is:
+
+```
+~/.secretctl/
+├── vault.salt       # Cryptographic salt (16 bytes)
+├── vault.meta       # Vault metadata (encrypted)
+├── vault.db         # SQLite database (encrypted)
+├── vault.lock       # Lock file for concurrent access
+├── audit/           # Audit logs directory
+│   └── *.jsonl      # JSON Lines audit log files
+└── mcp-policy.yaml  # MCP server policy (optional)
+```
+
+### File Permissions
+
+All files are created with secure permissions:
+
+| File/Directory | Permissions | Description |
+|---------------|-------------|-------------|
+| `~/.secretctl/` | `0700` | Directory accessible only by owner |
+| `vault.salt` | `0600` | Salt file (owner read/write only) |
+| `vault.meta` | `0600` | Metadata file (owner read/write only) |
+| `vault.db` | `0600` | Database file (owner read/write only) |
+| `mcp-policy.yaml` | `0600` | Policy file (required for MCP server) |
+| `audit/` | `0700` | Audit logs directory |
+
+**Important:** The MCP policy file must have `0600` permissions and be owned by the current user. Symlinks are not allowed for security reasons.
+
+---
+
+## MCP Policy Configuration
+
+Create `~/.secretctl/mcp-policy.yaml` to configure the MCP server:
+
+```yaml
+version: 1
+default_action: deny
+
+# Commands that are always blocked (hardcoded)
+# - env, printenv, set, export, cat /proc/*/environ
+
+# User-defined denied commands (checked first)
+denied_commands:
+  - rm
+  - mv
+  - sudo
+
+# Allowed commands (checked second)
+allowed_commands:
+  - aws
+  - gcloud
+  - kubectl
+  - curl
+  - wget
+  - ./deploy.sh
+
+# Environment aliases for key transformation
+env_aliases:
+  dev:
+    - pattern: "db/*"
+      target: "dev/db/*"
+    - pattern: "api/*"
+      target: "dev/api/*"
+  staging:
+    - pattern: "db/*"
+      target: "staging/db/*"
+    - pattern: "api/*"
+      target: "staging/api/*"
+  prod:
+    - pattern: "db/*"
+      target: "prod/db/*"
+    - pattern: "api/*"
+      target: "prod/api/*"
+```
+
+### Policy Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | integer | Yes | Policy version (must be `1`) |
+| `default_action` | string | No | Default action: `allow` or `deny` (default: `deny`) |
+| `denied_commands` | string[] | No | Commands to always block |
+| `allowed_commands` | string[] | No | Commands to allow |
+| `env_aliases` | map | No | Environment alias mappings |
+
+### Policy Evaluation Order
+
+1. **Hardcoded denies**: `env`, `printenv`, `set`, `export`, `cat /proc/*/environ`
+2. **User `denied_commands`**: Explicitly blocked commands
+3. **User `allowed_commands`**: Explicitly allowed commands
+4. **`default_action`**: Fallback (default: `deny`)
+
+### Environment Aliases
+
+Environment aliases allow different secret key mappings per environment:
+
+```yaml
+env_aliases:
+  dev:
+    - pattern: "db/*"      # Match keys like db/host, db/password
+      target: "dev/db/*"   # Transform to dev/db/host, dev/db/password
+  prod:
+    - pattern: "db/*"
+      target: "prod/db/*"
+```
+
+**Usage:**
+
+```bash
+# CLI: Use --env flag
+secretctl run --env=prod -k "db/*" -- ./deploy.sh
+
+# MCP: Use env parameter
+{
+  "keys": ["db/*"],
+  "command": "./deploy.sh",
+  "env": "prod"
+}
+```
+
+---
+
+## Validation Limits
+
+### Master Password
+
+| Constraint | Value |
+|------------|-------|
+| Minimum length | 8 characters |
+| Maximum length | 128 characters |
+
+### Secret Keys
+
+| Constraint | Value |
+|------------|-------|
+| Minimum length | 1 character |
+| Maximum length | 256 characters |
+| Allowed characters | Alphanumeric, `-`, `_`, `/`, `.` |
+
+### Secret Values
+
+| Constraint | Value |
+|------------|-------|
+| Maximum size | 1 MB (1,048,576 bytes) |
+
+### Metadata
+
+| Constraint | Value |
+|------------|-------|
+| Maximum notes size | 10 KB (10,240 bytes) |
+| Maximum URL length | 2,048 characters |
+| Maximum tag count | 10 tags |
+| Maximum tag length | 64 characters |
+
+---
+
+## Unlock Cooldown
+
+To protect against brute-force attacks, secretctl implements progressive cooldowns after failed unlock attempts:
+
+| Failed Attempts | Cooldown Duration |
+|----------------|-------------------|
+| 5 | 30 seconds |
+| 10 | 5 minutes |
+| 20 | 30 minutes |
+
+The cooldown counter resets after a successful unlock.
+
+---
+
+## Disk Space Requirements
+
+secretctl monitors available disk space:
+
+| Threshold | Action |
+|-----------|--------|
+| < 10 MB free | Vault operations blocked |
+| > 90% used | Warning displayed |
+| < 1 MB free | Audit logging blocked |
+
+---
+
+## Cryptographic Parameters
+
+### Key Derivation (Argon2id)
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | Argon2id |
+| Memory | 64 MB |
+| Iterations | 3 |
+| Parallelism | 4 threads |
+| Salt length | 16 bytes (128-bit) |
+| Output length | 32 bytes (256-bit) |
+
+These parameters follow OWASP recommendations for high-security applications.
+
+### Encryption (AES-256-GCM)
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | AES-256-GCM |
+| Key length | 256 bits |
+| Nonce length | 12 bytes (96-bit) |
+| Tag length | 16 bytes (128-bit) |
+
+### HMAC (Audit Chain)
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | HMAC-SHA256 |
+| Key derivation | HKDF-SHA256 |
+| Chain validation | Sequential verification |
+
+---
+
+## Shell Completion
+
+Install shell completion for enhanced CLI experience:
+
+### Bash
+
+```bash
+secretctl completion bash > /etc/bash_completion.d/secretctl
+# or for user-level installation
+secretctl completion bash > ~/.local/share/bash-completion/completions/secretctl
+```
+
+### Zsh
+
+```bash
+secretctl completion zsh > "${fpath[1]}/_secretctl"
+# or specify a custom directory
+secretctl completion zsh > ~/.zsh/completions/_secretctl
+```
+
+### Fish
+
+```bash
+secretctl completion fish > ~/.config/fish/completions/secretctl.fish
+```
+
+### PowerShell
+
+```powershell
+secretctl completion powershell | Out-String | Invoke-Expression
+# or save to profile
+secretctl completion powershell >> $PROFILE
+```
+
+---
+
+## Claude Code Integration
+
+Configure secretctl MCP server in `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "secretctl": {
+      "command": "/path/to/secretctl",
+      "args": ["mcp-server"],
+      "env": {
+        "SECRETCTL_PASSWORD": "your-master-password"
+      }
+    }
+  }
+}
+```
+
+**Security Considerations:**
+
+- Store `SECRETCTL_PASSWORD` securely (consider using a keychain or secret manager)
+- The MCP server only exposes metadata and masked values to AI agents
+- Configure `mcp-policy.yaml` to restrict which commands can be executed
+
+See [MCP Integration Guide](/docs/guides/mcp/) for detailed setup instructions.

--- a/website/docs/reference/mcp-tools.md
+++ b/website/docs/reference/mcp-tools.md
@@ -1,9 +1,565 @@
 ---
 title: MCP Tools
-description: MCP tools API reference.
+description: Complete API reference for secretctl MCP server tools.
 sidebar_position: 2
 ---
 
 # MCP Tools Reference
 
-Coming soon.
+Complete API reference for all MCP tools provided by the secretctl MCP server.
+
+## Overview
+
+The secretctl MCP server implements a security-first design where **AI agents never receive plaintext secrets**. This follows the "Option D+" architecture, aligned with 1Password's "Access Without Exposure" philosophy.
+
+**Available Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `secret_list` | List secret keys with metadata (no values) |
+| `secret_exists` | Check if a secret exists with metadata |
+| `secret_get_masked` | Get masked secret value (e.g., `****WXYZ`) |
+| `secret_run` | Execute command with secrets as environment variables |
+
+---
+
+## secret_list
+
+List all secret keys with metadata. Returns key names, tags, expiration, and flags for notes/URL presence. Does NOT return secret values.
+
+### Input Schema
+
+```json
+{
+  "tag": "string (optional)",
+  "expiring_within": "string (optional)"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tag` | string | No | Filter by tag |
+| `expiring_within` | string | No | Filter by expiration (e.g., `7d`, `30d`) |
+
+### Output Schema
+
+```json
+{
+  "secrets": [
+    {
+      "key": "string",
+      "tags": ["string"],
+      "expires_at": "string (RFC 3339, optional)",
+      "has_notes": "boolean",
+      "has_url": "boolean",
+      "created_at": "string (RFC 3339)",
+      "updated_at": "string (RFC 3339)"
+    }
+  ]
+}
+```
+
+### Examples
+
+**List all secrets:**
+
+```json
+// Input
+{}
+
+// Output
+{
+  "secrets": [
+    {
+      "key": "AWS_ACCESS_KEY",
+      "tags": ["aws", "prod"],
+      "has_notes": false,
+      "has_url": true,
+      "created_at": "2025-01-15T10:30:00Z",
+      "updated_at": "2025-01-15T10:30:00Z"
+    },
+    {
+      "key": "DB_PASSWORD",
+      "tags": ["db", "prod"],
+      "expires_at": "2025-06-15T00:00:00Z",
+      "has_notes": true,
+      "has_url": false,
+      "created_at": "2025-01-10T08:00:00Z",
+      "updated_at": "2025-01-10T08:00:00Z"
+    }
+  ]
+}
+```
+
+**Filter by tag:**
+
+```json
+// Input
+{
+  "tag": "prod"
+}
+
+// Output
+{
+  "secrets": [/* secrets with "prod" tag */]
+}
+```
+
+**Filter by expiration:**
+
+```json
+// Input
+{
+  "expiring_within": "30d"
+}
+
+// Output
+{
+  "secrets": [/* secrets expiring within 30 days */]
+}
+```
+
+---
+
+## secret_exists
+
+Check if a secret key exists and return its metadata. Does NOT return the secret value.
+
+### Input Schema
+
+```json
+{
+  "key": "string"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Yes | The secret key to check |
+
+### Output Schema
+
+```json
+{
+  "exists": "boolean",
+  "key": "string",
+  "tags": ["string"],
+  "expires_at": "string (RFC 3339, optional)",
+  "has_notes": "boolean",
+  "has_url": "boolean",
+  "created_at": "string (RFC 3339, optional)",
+  "updated_at": "string (RFC 3339, optional)"
+}
+```
+
+### Examples
+
+**Check existing secret:**
+
+```json
+// Input
+{
+  "key": "API_KEY"
+}
+
+// Output
+{
+  "exists": true,
+  "key": "API_KEY",
+  "tags": ["api", "prod"],
+  "has_notes": true,
+  "has_url": true,
+  "created_at": "2025-01-15T10:30:00Z",
+  "updated_at": "2025-01-15T10:30:00Z"
+}
+```
+
+**Check non-existent secret:**
+
+```json
+// Input
+{
+  "key": "NONEXISTENT_KEY"
+}
+
+// Output
+{
+  "exists": false,
+  "key": "NONEXISTENT_KEY",
+  "tags": null,
+  "has_notes": false,
+  "has_url": false
+}
+```
+
+---
+
+## secret_get_masked
+
+Get a masked version of a secret value (e.g., `****WXYZ`). Useful for verifying secret format without exposing the actual value.
+
+### Input Schema
+
+```json
+{
+  "key": "string"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Yes | The secret key to retrieve |
+
+### Output Schema
+
+```json
+{
+  "key": "string",
+  "masked_value": "string",
+  "value_length": "integer"
+}
+```
+
+### Masking Behavior
+
+The masking algorithm:
+- Shows the last 4 characters of the secret
+- Replaces all preceding characters with `*`
+- For secrets shorter than 8 characters, shows only asterisks
+
+| Secret Length | Masked Output |
+|--------------|---------------|
+| 1-7 chars | `*******` (all asterisks) |
+| 8+ chars | `****WXYZ` (last 4 visible) |
+
+### Examples
+
+**Get masked value:**
+
+```json
+// Input
+{
+  "key": "API_KEY"
+}
+
+// Output (assuming API_KEY = "sk-abc123xyz789")
+{
+  "key": "API_KEY",
+  "masked_value": "*********789",
+  "value_length": 14
+}
+```
+
+**Short secret:**
+
+```json
+// Input
+{
+  "key": "PIN"
+}
+
+// Output (assuming PIN = "1234")
+{
+  "key": "PIN",
+  "masked_value": "****",
+  "value_length": 4
+}
+```
+
+---
+
+## secret_run
+
+Execute a command with specified secrets injected as environment variables. Output is automatically sanitized to prevent secret leakage. Requires policy approval.
+
+### Input Schema
+
+```json
+{
+  "keys": ["string"],
+  "command": "string",
+  "args": ["string"],
+  "timeout": "string (optional)",
+  "env_prefix": "string (optional)",
+  "env": "string (optional)"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `keys` | string[] | Yes | Secret keys to inject (glob patterns supported) |
+| `command` | string | Yes | Command to execute |
+| `args` | string[] | No | Command arguments |
+| `timeout` | string | No | Execution timeout (e.g., `30s`, `5m`). Default: `5m` |
+| `env_prefix` | string | No | Prefix for environment variable names |
+| `env` | string | No | Environment alias (e.g., `dev`, `staging`, `prod`) |
+
+### Output Schema
+
+```json
+{
+  "exit_code": "integer",
+  "stdout": "string",
+  "stderr": "string",
+  "duration_ms": "integer",
+  "sanitized": "boolean"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exit_code` | integer | Command exit code (0 = success) |
+| `stdout` | string | Standard output (sanitized) |
+| `stderr` | string | Standard error (sanitized) |
+| `duration_ms` | integer | Execution duration in milliseconds |
+| `sanitized` | boolean | Whether output was sanitized |
+
+### Key Pattern Syntax
+
+The `keys` field supports glob patterns:
+
+| Pattern | Matches |
+|---------|---------|
+| `API_KEY` | Exact match for `API_KEY` |
+| `aws/*` | All keys under `aws/` (single level) |
+| `db/*` | All keys under `db/` (single level) |
+
+### Environment Variable Naming
+
+Secret keys are transformed to environment variable names:
+
+- `/` is replaced with `_`
+- `-` is replaced with `_`
+- Names are converted to UPPERCASE
+
+| Secret Key | Environment Variable |
+|------------|---------------------|
+| `aws/access_key` | `AWS_ACCESS_KEY` |
+| `db-password` | `DB_PASSWORD` |
+| `api/prod/key` | `API_PROD_KEY` |
+
+### Output Sanitization
+
+All command output is scanned for secret values. Any matches are replaced with `[REDACTED:key]`:
+
+```
+Original: "Connected to database with password secret123"
+Sanitized: "Connected to database with password [REDACTED:DB_PASSWORD]"
+```
+
+### Examples
+
+**Run with single secret:**
+
+```json
+// Input
+{
+  "keys": ["API_KEY"],
+  "command": "curl",
+  "args": ["-H", "Authorization: Bearer $API_KEY", "https://api.example.com"]
+}
+
+// Output
+{
+  "exit_code": 0,
+  "stdout": "{\"status\": \"ok\"}",
+  "stderr": "",
+  "duration_ms": 245,
+  "sanitized": false
+}
+```
+
+**Run with wildcard pattern:**
+
+```json
+// Input
+{
+  "keys": ["aws/*"],
+  "command": "aws",
+  "args": ["s3", "ls"]
+}
+
+// Output
+{
+  "exit_code": 0,
+  "stdout": "2025-01-15 10:30:00 my-bucket\n",
+  "stderr": "",
+  "duration_ms": 1250,
+  "sanitized": false
+}
+```
+
+**Run with environment alias:**
+
+```json
+// Input
+{
+  "keys": ["db/*"],
+  "command": "./deploy.sh",
+  "env": "prod"
+}
+
+// Output
+{
+  "exit_code": 0,
+  "stdout": "Deployment complete",
+  "stderr": "",
+  "duration_ms": 5000,
+  "sanitized": false
+}
+```
+
+**Run with prefix:**
+
+```json
+// Input
+{
+  "keys": ["API_KEY"],
+  "command": "./app",
+  "env_prefix": "MYAPP_"
+}
+
+// Environment variables:
+// MYAPP_API_KEY=<value>
+
+// Output
+{
+  "exit_code": 0,
+  "stdout": "Application started",
+  "stderr": "",
+  "duration_ms": 100,
+  "sanitized": false
+}
+```
+
+---
+
+## Policy Configuration
+
+The `secret_run` tool requires policy approval. Create `~/.secretctl/mcp-policy.yaml`:
+
+```yaml
+version: 1
+default_action: deny
+
+# Commands that are always blocked (security)
+# - env, printenv, set, export, cat /proc/*/environ
+
+# User-defined denied commands
+denied_commands: []
+
+# Allowed commands (required when default_action is deny)
+allowed_commands:
+  - aws
+  - gcloud
+  - kubectl
+  - curl
+  - ./deploy.sh
+
+# Environment aliases for key transformation
+env_aliases:
+  dev:
+    - pattern: "db/*"
+      target: "dev/db/*"
+  prod:
+    - pattern: "db/*"
+      target: "prod/db/*"
+```
+
+### Policy Evaluation Order
+
+1. **Default denied commands** (always blocked): `env`, `printenv`, `set`, `export`
+2. **User-defined `denied_commands`**: Explicitly blocked commands
+3. **User-defined `allowed_commands`**: Explicitly allowed commands
+4. **`default_action`**: Fallback action (`allow` or `deny`)
+
+### Security Requirements
+
+The policy file must meet these requirements:
+- File permissions: `0600` (owner read/write only)
+- No symlinks (direct file only)
+- Owned by current user
+
+---
+
+## Security Design
+
+### Option D+ Architecture
+
+The secretctl MCP server follows the "Option D+" security model:
+
+| Tool | Plaintext Access | Purpose |
+|------|-----------------|---------|
+| `secret_list` | No | List keys and metadata only |
+| `secret_exists` | No | Check existence and metadata |
+| `secret_get_masked` | No | Verify format without exposure |
+| `secret_run` | No* | Inject via environment variables |
+
+\* Secrets are injected as environment variables into the child process. The AI agent never sees the plaintext values.
+
+### Why No `secret_get`?
+
+A `secret_get` tool that returns plaintext values is intentionally **not implemented**. This design choice aligns with:
+
+- **1Password**: Explicitly refuses to expose raw credentials via MCP
+- **HashiCorp Vault**: "Raw secrets never exposed" policy
+- **Industry best practice**: Minimize secret exposure surface
+
+### Output Sanitization
+
+The `secret_run` tool automatically sanitizes command output to prevent accidental secret leakage:
+
+- Exact string matching for secret values
+- Replacement with `[REDACTED:key]` placeholder
+- Applied to both stdout and stderr
+
+**Limitations:**
+- Base64 or hex-encoded secrets are not detected
+- Partial matches are not detected
+- Obfuscated or transformed values are not detected
+
+---
+
+## Error Handling
+
+### Common Errors
+
+| Error | Description |
+|-------|-------------|
+| `secret not found` | The requested secret key does not exist |
+| `policy not found` | No MCP policy file exists |
+| `command not allowed` | Command blocked by policy |
+| `timeout exceeded` | Command execution exceeded timeout |
+
+### Error Response Format
+
+```json
+{
+  "error": {
+    "code": -32000,
+    "message": "secret not found: API_KEY"
+  }
+}
+```
+
+---
+
+## Integration Example
+
+Configure in Claude Code (`~/.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "secretctl": {
+      "command": "/path/to/secretctl",
+      "args": ["mcp-server"],
+      "env": {
+        "SECRETCTL_PASSWORD": "your-master-password"
+      }
+    }
+  }
+}
+```
+
+See [MCP Integration Guide](/docs/guides/mcp/) for detailed setup instructions.


### PR DESCRIPTION
## Summary

Add complete Reference documentation section with three comprehensive documents:

- **CLI Commands Reference** (`cli-commands.md`): Complete reference for all 11 CLI commands including `init`, `set`, `get`, `delete`, `list`, `run`, `export`, `generate`, `audit` (with subcommands), `mcp-server`, and `completion`. Each command includes syntax, flags table, and practical examples.

- **MCP Tools Reference** (`mcp-tools.md`): API reference for all 4 MCP tools (`secret_list`, `secret_exists`, `secret_get_masked`, `secret_run`). Includes input/output JSON schemas, examples, policy configuration, and security design explanation (Option D+ architecture).

- **Configuration Reference** (`configuration.md`): Environment variables, file structure, MCP policy configuration, validation limits, cryptographic parameters, and shell completion setup.

## Changes

- `website/docs/reference/cli-commands.md`: +445 lines
- `website/docs/reference/mcp-tools.md`: +560 lines  
- `website/docs/reference/configuration.md`: +317 lines

## Test Plan

- [ ] Verify documentation builds without errors (`npm run build` in website/)
- [ ] Check internal links resolve correctly
- [ ] Review technical accuracy against source code

## Review Notes

- All schemas verified against Go structs in `internal/mcp/tools.go`
- Cryptographic parameters verified against `pkg/crypto/crypto.go` and `pkg/vault/vault.go`
- Environment variables verified against actual usage in codebase