### PR TITLE
fix(mcp): enhance secret redaction to prevent leakage via encoding

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -703,8 +703,8 @@ func newOutputSanitizer(secrets []secretData) *outputSanitizer {
 		addReplacement([]byte(base64.RawURLEncoding.EncodeToString(secret.value)), placeholder)
 
 		// URL-encoded forms
-		addReplacement([]byte(url.QueryEscape(string(secret.value))), placeholder)   // space as +
-		addReplacement([]byte(url.PathEscape(string(secret.value))), placeholder)    // space as %20
+		addReplacement([]byte(url.QueryEscape(string(secret.value))), placeholder)    // space as +
+		addReplacement([]byte(url.PathEscape(string(secret.value))), placeholder)     // space as %20
 		addReplacement([]byte(percentEncodeLower(string(secret.value))), placeholder) // lowercase %xx
 
 		// Hex-encoded forms (plain)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -400,7 +400,7 @@ func TestOutputSanitizerEncodedForms(t *testing.T) {
 		},
 		{
 			name:     "base64 encoded (padded)",
-			input:    "encoded=cGFzc3dvcmQ=", // base64("password")
+			input:    "encoded=cGFzc3dvcmQ=", // "password" in base64
 			expected: "encoded=[REDACTED:SECRET]",
 		},
 		{
@@ -410,7 +410,7 @@ func TestOutputSanitizerEncodedForms(t *testing.T) {
 		},
 		{
 			name:     "hex lowercase",
-			input:    "hex=70617373776f7264", // hex("password")
+			input:    "hex=70617373776f7264", // "password" in hex
 			expected: "hex=[REDACTED:SECRET]",
 		},
 		{
@@ -459,12 +459,12 @@ func TestOutputSanitizerURLEncoded(t *testing.T) {
 		},
 		{
 			name:     "QueryEscape (space as +)",
-			input:    "p=pass+word%21", // url.QueryEscape("pass word!")
+			input:    "p=pass+word%21", // space becomes + in query encoding
 			expected: "p=[REDACTED:PASS]",
 		},
 		{
 			name:     "PathEscape (space as %20)",
-			input:    "p=pass%20word%21", // url.PathEscape("pass word!")
+			input:    "p=pass%20word%21", // space becomes %20 in path encoding
 			expected: "p=[REDACTED:PASS]",
 		},
 		{


### PR DESCRIPTION
## Summary
- Fixes #60: Incomplete secret redaction in secret_run

## Changes
- Redact ALL secrets regardless of length (not just >= 4 bytes)
- Detect and redact Base64-encoded forms (padded and raw/unpadded)
- Detect and redact URL-encoded forms (QueryEscape and PathEscape)
- Detect and redact hex-encoded forms with 0x/0X prefixes
- Use sort.Slice for clearer sorting logic
- Deduplicate replacement patterns to avoid redundant work
- Add comprehensive tests for all encoding detection

## Security
This prevents secrets from leaking through MCP output when commands echo environment variables in encoded forms (e.g., base64, hex, URL-encoded).

## Test plan
- [x] All existing tests pass
- [x] New tests for encoded forms (Base64, URL, hex) added
- [x] Test for raw/unpadded Base64 (JWT segments)
- [x] Test for 0x-prefixed hex (debug output)
- [x] Codex review passed