### PR TITLE
feat(mcp): add audit logging for all MCP operations (#65)

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -533,6 +533,11 @@ func (v *Vault) Lock() {
 	}
 }
 
+// Audit returns the vault's audit logger for MCP and other external use.
+func (v *Vault) Audit() *audit.Logger {
+	return v.audit
+}
+
 // IsLocked returns whether the vault is locked
 func (v *Vault) IsLocked() bool {
 	v.mu.RLock()


### PR DESCRIPTION
## Summary
- Add `Vault.Audit()` getter method to expose audit logger for MCP
- Add audit logging to all 4 MCP handlers:
  - `handleSecretList`: logs success/error for list operations
  - `handleSecretExists`: logs success/error for existence checks
  - `handleSecretGetMasked`: logs success/error for masked value retrieval
  - `handleSecretRun`: logs success/denied/error for command execution

## Security
- All key names are HMAC-hashed before storage in audit log
- No plaintext secret values logged
- Audit failures are silently ignored (non-blocking)
- `OpSecretRunDenied` distinguishes policy denials from errors

## Test Plan
- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] Security review completed

Closes #65