### PR TITLE
feat(ci): add test coverage reporting with Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ No infrastructure. No subscription. No complexity.
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-website-blue)](https://forest6511.github.io/secretctl/)
+[![Codecov](https://codecov.io/gh/forest6511/secretctl/branch/main/graph/badge.svg)](https://codecov.io/gh/forest6511/secretctl)
 
 ---
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,53 @@
+# Codecov configuration for secretctl
+# See: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    # Overall project coverage threshold
+    project:
+      default:
+        target: 70%
+        threshold: 2%
+        informational: false
+      # Critical package: crypto (informational until coverage improves)
+      crypto:
+        paths:
+          - "pkg/crypto/**"
+        target: 80%
+        threshold: 2%
+        informational: true
+      # Critical package: vault (informational until coverage improves)
+      vault:
+        paths:
+          - "pkg/vault/**"
+        target: 80%
+        threshold: 2%
+        informational: true
+    # Coverage for new code in PRs
+    patch:
+      default:
+        target: 70%
+        threshold: 1%
+        informational: false
+
+# Ignore generated files and test files
+ignore:
+  - "**/*_test.go"
+  - "**/mock_*.go"
+  - "**/mocks/**"
+  - "desktop/frontend/**"
+
+# Comment configuration for PRs
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+# Flags for different test types
+flags:
+  unittests:
+    paths:
+      - "pkg/**"
+    carryforward: true


### PR DESCRIPTION
## Summary
- Add codecov.yml with coverage thresholds (70% overall, 80% for crypto/vault)
- Add Codecov badge to README (pinned to main branch)
- Configure PR comments and coverage flags

## Changes
- `codecov.yml`: New Codecov configuration file
- `README.md`: Added Codecov badge

Closes #55