### PR TITLE
docs: standardize GoDoc documentation comments

### DIFF
--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,5 +1,31 @@
-// Package audit provides audit logging with HMAC chain for tamper detection.
-// Implements requirements-ja.md §7 and security-design-ja.md §8.
+// Package audit provides tamper-evident audit logging with HMAC chaining.
+//
+// This package implements cryptographically secure audit logging where each
+// event is linked to the previous via HMAC, creating an immutable chain that
+// detects any tampering or deletion of records.
+//
+// # Security Features
+//
+//   - HMAC-SHA256 chaining for tamper detection
+//   - Derived audit key from master password via HKDF
+//   - Unique event IDs with timestamp prefix for chronological ordering
+//   - Session tracking for correlated events
+//   - Disk space checks before writing
+//
+// # Event Structure
+//
+// Each audit event records:
+//   - Operation type (vault.unlock, secret.get, etc.)
+//   - Actor information (user, source, session)
+//   - Result (success, error, denied)
+//   - Chain verification data (sequence, previous hash)
+//
+// # Example Usage
+//
+//	logger := audit.NewLogger("/path/to/vault/audit")
+//	logger.SetHMACKey(derivedKey)
+//	err := logger.LogSuccess(audit.OpSecretGet, audit.SourceCLI, "API_KEY")
+//	result, err := logger.Verify()
 package audit
 
 import (

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -1,3 +1,30 @@
+// Package crypto provides cryptographic primitives for secretctl.
+//
+// This package implements AES-256-GCM authenticated encryption and Argon2id
+// key derivation following OWASP recommendations.
+//
+// # Security Features
+//
+//   - AES-256-GCM authenticated encryption
+//   - Argon2id key derivation (64MB memory, 3 iterations, 4 threads)
+//   - Cryptographically secure random nonce generation
+//   - Secure memory wiping for sensitive data
+//
+// # Example Usage
+//
+//	// Derive a key from password
+//	salt := make([]byte, 16)
+//	rand.Read(salt)
+//	key := crypto.DeriveKey([]byte("password"), salt)
+//
+//	// Encrypt data
+//	ciphertext, nonce, err := crypto.Encrypt(key, plaintext)
+//
+//	// Decrypt data
+//	plaintext, err := crypto.Decrypt(key, ciphertext, nonce)
+//
+//	// Securely wipe sensitive data
+//	crypto.SecureWipe(key)
 package crypto
 
 import (
@@ -11,32 +38,65 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-// Argon2idパラメータ（security-design-ja.md準拠、OWASP推奨値）
+// Argon2id parameters following OWASP recommendations.
 const (
-	Argon2Memory  = 64 * 1024 // 64MB
-	Argon2Time    = 3         // 反復回数
-	Argon2Threads = 4         // 並列度
-	KeyLength     = 32        // AES-256用（256-bit）
-	NonceLength   = 12        // GCM標準（96-bit）
+	// Argon2Memory is the memory cost in KiB (64MB).
+	Argon2Memory = 64 * 1024
+
+	// Argon2Time is the number of iterations.
+	Argon2Time = 3
+
+	// Argon2Threads is the degree of parallelism.
+	Argon2Threads = 4
+
+	// KeyLength is the length of encryption keys in bytes (256 bits).
+	KeyLength = 32
+
+	// NonceLength is the length of GCM nonces in bytes (96 bits).
+	NonceLength = 12
 )
 
+// Sentinel errors returned by crypto functions.
 var (
-	ErrInvalidKeyLength   = errors.New("crypto: invalid key length, must be 32 bytes")
+	// ErrInvalidKeyLength indicates the key is not 32 bytes.
+	ErrInvalidKeyLength = errors.New("crypto: invalid key length, must be 32 bytes")
+
+	// ErrInvalidNonceLength indicates the nonce is not 12 bytes.
 	ErrInvalidNonceLength = errors.New("crypto: invalid nonce length, must be 12 bytes")
-	ErrDecryptionFailed   = errors.New("crypto: decryption failed, authentication tag verification failed")
+
+	// ErrDecryptionFailed indicates decryption or authentication tag verification failed.
+	ErrDecryptionFailed = errors.New("crypto: decryption failed, authentication tag verification failed")
+
+	// ErrCiphertextTooShort indicates the ciphertext is shorter than the GCM tag.
 	ErrCiphertextTooShort = errors.New("crypto: ciphertext too short")
 )
 
-// DeriveKey はマスターパスワードとソルトからArgon2idを用いてKEKを導出する。
-// security-design-ja.mdに記載されたパラメータを使用:
-// memory=64MB, time=3, threads=4
+// DeriveKey derives a 256-bit encryption key from a password using Argon2id.
+//
+// The function uses OWASP-recommended parameters:
+//   - Memory: 64 MB
+//   - Iterations: 3
+//   - Parallelism: 4 threads
+//
+// The salt should be at least 16 bytes of cryptographically secure random data.
+// Returns a 32-byte key suitable for AES-256 encryption.
 func DeriveKey(password, salt []byte) []byte {
 	return argon2.IDKey(password, salt, Argon2Time, Argon2Memory, Argon2Threads, KeyLength)
 }
 
-// Encrypt は平文データをAES-256-GCMで暗号化する。
-// 戻り値: 暗号文、ノンス（96-bit）、エラー
-// ノンスはcrypto/randで安全に生成される。
+// Encrypt encrypts plaintext using AES-256-GCM authenticated encryption.
+//
+// The function generates a cryptographically secure random 12-byte nonce
+// using crypto/rand. The authentication tag is appended to the ciphertext.
+//
+// Parameters:
+//   - key: 32-byte encryption key (use DeriveKey to generate)
+//   - plaintext: data to encrypt (can be any length)
+//
+// Returns:
+//   - ciphertext: encrypted data with authentication tag
+//   - nonce: 12-byte nonce (must be stored with ciphertext for decryption)
+//   - err: ErrInvalidKeyLength if key is not 32 bytes
 func Encrypt(key, plaintext []byte) (ciphertext []byte, nonce []byte, err error) {
 	if len(key) != KeyLength {
 		return nil, nil, ErrInvalidKeyLength
@@ -52,20 +112,33 @@ func Encrypt(key, plaintext []byte) (ciphertext []byte, nonce []byte, err error)
 		return nil, nil, fmt.Errorf("crypto: failed to create GCM: %w", err)
 	}
 
-	// crypto/randで安全にノンスを生成
+	// Generate cryptographically secure random nonce
 	nonce = make([]byte, NonceLength)
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, nil, fmt.Errorf("crypto: failed to generate nonce: %w", err)
 	}
 
-	// GCMで暗号化（認証タグは暗号文に付加される）
+	// Encrypt with GCM (authentication tag is appended to ciphertext)
 	ciphertext = gcm.Seal(nil, nonce, plaintext, nil)
 
 	return ciphertext, nonce, nil
 }
 
-// Decrypt はAES-256-GCMで暗号化されたデータを復号する。
-// GCMによる認証タグの検証が失敗した場合はエラーを返す。
+// Decrypt decrypts ciphertext using AES-256-GCM authenticated encryption.
+//
+// The function verifies the authentication tag before returning the plaintext.
+// If the tag verification fails (indicating tampering or corruption),
+// ErrDecryptionFailed is returned.
+//
+// Parameters:
+//   - key: 32-byte encryption key (same key used for encryption)
+//   - ciphertext: encrypted data with authentication tag
+//   - nonce: 12-byte nonce used during encryption
+//
+// Returns:
+//   - plaintext: decrypted data
+//   - err: ErrInvalidKeyLength, ErrInvalidNonceLength, ErrCiphertextTooShort,
+//     or ErrDecryptionFailed
 func Decrypt(key, ciphertext, nonce []byte) (plaintext []byte, err error) {
 	if len(key) != KeyLength {
 		return nil, ErrInvalidKeyLength
@@ -85,12 +158,12 @@ func Decrypt(key, ciphertext, nonce []byte) (plaintext []byte, err error) {
 		return nil, fmt.Errorf("crypto: failed to create GCM: %w", err)
 	}
 
-	// 暗号文が最低限の長さを持つか確認（GCMタグ16バイト）
+	// Verify ciphertext has minimum length (GCM tag is 16 bytes)
 	if len(ciphertext) < gcm.Overhead() {
 		return nil, ErrCiphertextTooShort
 	}
 
-	// GCMで復号（認証タグ検証を含む）
+	// Decrypt with GCM (includes authentication tag verification)
 	plaintext, err = gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, ErrDecryptionFailed

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -1,5 +1,33 @@
 // Package vault provides secure secret storage with AES-256-GCM encryption.
-// Implements the vault management specified in security-design-ja.md §2-3.
+//
+// The vault stores secrets in an encrypted SQLite database, using a master
+// password to derive the encryption key via Argon2id. All secrets are
+// encrypted individually with unique nonces.
+//
+// # Security Features
+//
+//   - AES-256-GCM authenticated encryption for all secrets
+//   - Argon2id key derivation with OWASP-recommended parameters
+//   - HMAC-chained audit logging for tamper detection
+//   - Rate limiting for unlock attempts (5/10/20 failures = 30s/5m/30m cooldown)
+//   - Secure file permissions (0600 for files, 0700 for directories)
+//
+// # Example Usage
+//
+//	// Create and initialize a new vault
+//	v := vault.New("/path/to/vault")
+//	err := v.Init("masterpassword")
+//
+//	// Open an existing vault
+//	v := vault.New("/path/to/vault")
+//	err := v.Unlock("masterpassword")
+//
+//	// Store and retrieve secrets
+//	err = v.SetSecret("API_KEY", &vault.SecretEntry{Value: []byte("secret")})
+//	entry, err := v.GetSecret("API_KEY")
+//
+//	// Lock when done
+//	err = v.Lock()
 package vault
 
 import (


### PR DESCRIPTION
## Summary
- Standardize package documentation for crypto, vault, and audit packages
- Add comprehensive package-level GoDoc comments with examples
- Document security features and usage patterns
- Update constant and error variable documentation
- Add parameter and return value documentation for functions
- Remove references to internal Japanese documentation

## Changes
- `pkg/crypto/crypto.go`: Added package overview, security features, and example usage
- `pkg/vault/vault.go`: Added package overview, security features, and corrected API examples
- `pkg/audit/audit.go`: Added package overview, event structure docs, and corrected API examples

Closes #58