### PR TITLE
fix(crypto): add nosec directive for false positive G407

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -119,6 +119,7 @@ func Encrypt(key, plaintext []byte) (ciphertext []byte, nonce []byte, err error)
 	}
 
 	// Encrypt with GCM (authentication tag is appended to ciphertext)
+	// #nosec G407 -- nonce is randomly generated above using crypto/rand.Read()
 	ciphertext = gcm.Seal(nil, nonce, plaintext, nil)
 
 	return ciphertext, nonce, nil


### PR DESCRIPTION
## Summary

Fix gosec false positive that was blocking the v0.5.0 release.

## Problem

The gosec security scanner incorrectly flagged `gcm.Seal()` as using a hardcoded nonce (G407 - CWE-1204), but the nonce is actually generated using `crypto/rand.Read()` on the lines immediately above.

```go
// Line 116-118: nonce is randomly generated
nonce = make([]byte, NonceLength)
if _, err := rand.Read(nonce); err != nil {
    return nil, nil, fmt.Errorf("crypto: failed to generate nonce: %w", err)
}

// Line 122: gosec incorrectly thinks this is hardcoded
ciphertext = gcm.Seal(nil, nonce, plaintext, nil)
```

## Solution

Add `#nosec G407` directive with an explanation comment to suppress the false positive.

## Test plan

- [ ] CI passes (including gosec security scan)
- [ ] Release workflow can complete successfully