### PR TITLE
fix(ci): exclude desktop from gosec scan in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Run security scan
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@latest
-          gosec -severity high -confidence high ./...
+          # Exclude desktop/ as it requires Wails dependencies not available in this job
+          gosec -severity high -confidence high -exclude-dir=desktop ./...
 
       - name: Check vulnerabilities
         run: |


### PR DESCRIPTION
## Summary

Fix the release workflow failure by excluding desktop/ directory from gosec security scan.

## Problem

The gosec tool fails when scanning desktop/ because Wails v2 dependencies are not installed in the test job. This blocks the entire release workflow.

```
Golang errors in file: [desktop/main.go]:
  > could not import github.com/wailsapp/wails/v2 (invalid package name: "")
```

## Solution

Add `-exclude-dir=desktop` to the gosec command. The desktop directory is scanned and built separately in the `desktop-build` job where Wails dependencies are properly installed.

## Test plan

- [ ] Release workflow completes successfully
- [ ] Security scan runs on non-desktop code