### PR TITLE
fix(ci): correct MCP path in Option D+ checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Option D+ Check - No plaintext secret returns
         run: |
           set -euo pipefail
-          if grep -rn "secret_get\s*=" pkg/mcp/ 2>/dev/null | grep -v "masked\|Masked"; then
-            echo "FAIL: Plaintext secret getter found in pkg/mcp/"
+          if grep -rn "secret_get\s*=" internal/mcp/ 2>/dev/null | grep -v "masked\|Masked"; then
+            echo "FAIL: Plaintext secret getter found in internal/mcp/"
             exit 1
           fi
           echo "OK: No plaintext secret getters"
@@ -63,8 +63,8 @@ jobs:
       - name: Option D+ Check - Output sanitization
         run: |
           set -euo pipefail
-          if ! grep -rq "Sanitize\|sanitize\|REDACTED" pkg/mcp/ 2>/dev/null; then
-            echo "FAIL: No output sanitization found in pkg/mcp/"
+          if ! grep -rq "Sanitize\|sanitize\|REDACTED" internal/mcp/ 2>/dev/null; then
+            echo "FAIL: No output sanitization found in internal/mcp/"
             exit 1
           fi
           echo "OK: Output sanitization found"
@@ -72,8 +72,8 @@ jobs:
       - name: Option D+ Check - Audit logging
         run: |
           set -euo pipefail
-          if ! grep -rq "audit\.\|Audit\|AuditLog" pkg/mcp/ 2>/dev/null; then
-            echo "FAIL: No audit logging found in pkg/mcp/"
+          if ! grep -rq "audit\.\|Audit\|AuditLog" internal/mcp/ 2>/dev/null; then
+            echo "FAIL: No audit logging found in internal/mcp/"
             exit 1
           fi
           echo "OK: Audit logging found"
@@ -81,8 +81,8 @@ jobs:
       - name: Option D+ Check - Masked returns
         run: |
           set -euo pipefail
-          if ! grep -rq "Masked\|masked" pkg/mcp/ 2>/dev/null; then
-            echo "FAIL: No masked returns found in pkg/mcp/"
+          if ! grep -rq "Masked\|masked" internal/mcp/ 2>/dev/null; then
+            echo "FAIL: No masked returns found in internal/mcp/"
             exit 1
           fi
           echo "OK: Masked returns found"


### PR DESCRIPTION
## Summary

- Fix Option D+ compliance checks in release workflow to use correct path
- Changed `pkg/mcp/` to `internal/mcp/` in all 4 checks

## Root Cause

The release workflow was looking for MCP code in `pkg/mcp/` but the actual implementation is in `internal/mcp/`.

## Changes

Updated paths in:
- Option D+ Check - No plaintext secret returns
- Option D+ Check - Output sanitization  
- Option D+ Check - Audit logging
- Option D+ Check - Masked returns

## Testing

Verified locally that all checks pass with correct path:
```
OK: Output sanitization found
OK: Audit logging found
OK: Masked returns found
```