### PR TITLE
fix: add cross-platform support for Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,16 +146,19 @@ jobs:
           - os: ubuntu-latest
             platform: linux/amd64
             artifact_name: secretctl-desktop-linux
+            wails_tags: webkit2_41
             deps_cmd: |
               sudo apt-get update
-              sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+              sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
           - os: macos-latest
             platform: darwin/universal
             artifact_name: secretctl-desktop-macos
+            wails_tags: ""
             deps_cmd: ""
           - os: windows-latest
             platform: windows/amd64
             artifact_name: secretctl-desktop-windows.exe
+            wails_tags: ""
             deps_cmd: choco install nsis -y
     runs-on: ${{ matrix.os }}
     steps:
@@ -191,7 +194,12 @@ jobs:
       - name: Build Desktop app
         run: |
           cd desktop
-          wails build -platform ${{ matrix.platform }}
+          if [ -n "${{ matrix.wails_tags }}" ]; then
+            wails build -platform ${{ matrix.platform }} -tags ${{ matrix.wails_tags }}
+          else
+            wails build -platform ${{ matrix.platform }}
+          fi
+        shell: bash
 
       - name: Upload Desktop artifact
         uses: actions/upload-artifact@v4

--- a/cmd/secretctl/run_unix.go
+++ b/cmd/secretctl/run_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// signalsToNotify returns the signals that should be forwarded to child processes
+func signalsToNotify() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
+}
+
+// terminateSignal returns the signal to send for graceful termination
+func terminateSignal() os.Signal {
+	return syscall.SIGTERM
+}
+
+// disableCoreDumps sets RLIMIT_CORE to 0 to prevent core dumps
+func disableCoreDumps() error {
+	var rLimit syscall.Rlimit
+	rLimit.Cur = 0
+	rLimit.Max = 0
+	return syscall.Setrlimit(syscall.RLIMIT_CORE, &rLimit)
+}

--- a/cmd/secretctl/run_windows.go
+++ b/cmd/secretctl/run_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// signalsToNotify returns the signals that should be forwarded to child processes
+// On Windows, only os.Interrupt is available (Ctrl+C)
+func signalsToNotify() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}
+
+// terminateSignal returns the signal to send for graceful termination
+// On Windows, os.Kill is used as there's no SIGTERM equivalent
+func terminateSignal() os.Signal {
+	return os.Kill
+}
+
+// disableCoreDumps is a no-op on Windows.
+// Windows uses different mechanisms for crash dumps (WER).
+func disableCoreDumps() error {
+	// Windows Error Reporting handles crash dumps differently
+	// and doesn't use RLIMIT_CORE. This is a security best-effort.
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/spf13/cobra v1.10.1
 	golang.org/x/crypto v0.45.0
+	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -17,5 +18,4 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 )

--- a/internal/mcp/policy_unix.go
+++ b/internal/mcp/policy_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// openPolicyFile opens the policy file with O_NOFOLLOW to reject symlinks
+func openPolicyFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrPolicyNotFound
+		}
+		if os.IsPermission(err) || errors.Is(err, syscall.ELOOP) {
+			return nil, ErrPolicySymlink
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// checkFileOwnership verifies the file is owned by the current user
+func checkFileOwnership(info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok {
+		if stat.Uid != uint32(os.Getuid()) {
+			return ErrPolicyNotOwnedByUser
+		}
+	}
+	return nil
+}

--- a/internal/mcp/policy_windows.go
+++ b/internal/mcp/policy_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package mcp
+
+import (
+	"os"
+)
+
+// openPolicyFile opens the policy file on Windows.
+// Windows doesn't have O_NOFOLLOW, but symlinks are less common on Windows
+// and require special privileges to create.
+func openPolicyFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrPolicyNotFound
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// checkFileOwnership on Windows is a no-op.
+// Windows uses ACLs for file ownership which requires different handling.
+// The permission check (0600 equivalent) is the primary security control.
+func checkFileOwnership(_ os.FileInfo) error {
+	// Windows uses different security model (ACLs)
+	// Skip ownership check, rely on file permissions
+	return nil
+}

--- a/pkg/audit/audit_unix.go
+++ b/pkg/audit/audit_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package audit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// checkDiskSpace verifies sufficient disk space for audit log writes
+func (l *Logger) checkDiskSpace() error {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(l.path, &stat); err != nil {
+		// If audit directory doesn't exist yet, check parent
+		parentDir := filepath.Dir(l.path)
+		if err := syscall.Statfs(parentDir, &stat); err != nil {
+			// Log warning but don't block audit operation
+			fmt.Fprintf(os.Stderr, "warning: failed to check disk space for audit: %v\n", err)
+			return nil
+		}
+	}
+
+	available := stat.Bavail * uint64(stat.Bsize)
+	if available < MinAuditDiskSpace {
+		return fmt.Errorf("audit: insufficient disk space: only %d bytes available, need at least %d",
+			available, MinAuditDiskSpace)
+	}
+
+	return nil
+}

--- a/pkg/audit/audit_windows.go
+++ b/pkg/audit/audit_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package audit
+
+// checkDiskSpace on Windows returns nil as disk space checking
+// is not implemented for Windows. Audit operations proceed without
+// disk space verification.
+func (l *Logger) checkDiskSpace() error {
+	return nil
+}

--- a/pkg/vault/vault_unix.go
+++ b/pkg/vault/vault_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package vault
+
+import (
+	"fmt"
+	"path/filepath"
+	"syscall"
+)
+
+// CheckDiskSpace returns disk space information for the vault directory
+func (v *Vault) CheckDiskSpace() (*DiskSpaceInfo, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(v.path, &stat); err != nil {
+		// If vault directory doesn't exist yet, check parent
+		parentDir := filepath.Dir(v.path)
+		if err := syscall.Statfs(parentDir, &stat); err != nil {
+			return nil, fmt.Errorf("vault: failed to get disk stats: %w", err)
+		}
+	}
+
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bfree * uint64(stat.Bsize)
+	available := stat.Bavail * uint64(stat.Bsize)
+
+	usedPct := 0
+	if total > 0 {
+		usedPct = int(100 * (total - free) / total)
+	}
+
+	return &DiskSpaceInfo{
+		Total:     total,
+		Free:      free,
+		Available: available,
+		UsedPct:   usedPct,
+	}, nil
+}

--- a/pkg/vault/vault_windows.go
+++ b/pkg/vault/vault_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package vault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// CheckDiskSpace returns disk space information for the vault directory
+func (v *Vault) CheckDiskSpace() (*DiskSpaceInfo, error) {
+	path := v.path
+	// Use parent directory if vault path doesn't exist
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		path = filepath.Dir(path)
+	}
+
+	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("vault: failed to convert path: %w", err)
+	}
+
+	err = windows.GetDiskFreeSpaceEx(pathPtr, &freeBytesAvailable, &totalBytes, &totalFreeBytes)
+	if err != nil {
+		return nil, fmt.Errorf("vault: failed to get disk stats: %w", err)
+	}
+
+	usedPct := 0
+	if totalBytes > 0 {
+		usedPct = int(100 * (totalBytes - totalFreeBytes) / totalBytes)
+	}
+
+	return &DiskSpaceInfo{
+		Total:     totalBytes,
+		Free:      totalFreeBytes,
+		Available: freeBytesAvailable,
+		UsedPct:   usedPct,
+	}, nil
+}


### PR DESCRIPTION
## Summary

This PR adds platform-specific implementations for Unix-specific syscall operations to enable Windows cross-compilation and native builds.

## Changes

### Platform-specific files added

| Package | Files | Description |
|---------|-------|-------------|
| `pkg/audit` | `audit_unix.go`, `audit_windows.go` | Disk space checking |
| `pkg/vault` | `vault_unix.go`, `vault_windows.go` | Disk space info |
| `internal/mcp` | `policy_unix.go`, `policy_windows.go` | Policy file loading (symlink/ownership checks) |
| `cmd/secretctl` | `run_unix.go`, `run_windows.go` | Signal handling and core dump disabling |

### Release workflow fixes

- Updated Ubuntu 24.04 to use `libwebkit2gtk-4.1-dev` instead of `4.0-dev`
- Added `webkit2_41` build tag for Wails on Ubuntu 24.04

## Testing

All cross-compilation targets verified locally:
- `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./cmd/secretctl` ✅
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/secretctl` ✅
- Native build (`go build ./...`) ✅
- Tests (`go test ./...`) ✅

## Root Cause

The previous code used Unix-specific syscalls that don't exist on Windows:
- `syscall.Statfs_t`, `syscall.Statfs` - for disk space checking
- `syscall.O_NOFOLLOW`, `syscall.ELOOP`, `syscall.Stat_t` - for policy file security
- `syscall.SIGTERM`, `syscall.SIGHUP` - for signal handling
- `syscall.Rlimit`, `syscall.Setrlimit`, `syscall.RLIMIT_CORE` - for core dump disabling