### PR TITLE
fix(ci): handle macOS app bundle in release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,13 +243,23 @@ jobs:
           path: dist/
         continue-on-error: true
 
+      - name: Package macOS app bundle
+        run: |
+          cd dist
+          # Zip macOS .app bundle if it exists
+          if [ -d "secretctl.app" ]; then
+            zip -r secretctl-desktop-macos.zip secretctl.app
+            rm -rf secretctl.app
+          fi
+
       - name: List artifacts
         run: ls -la dist/
 
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum * > checksums.txt
+          # Only checksum files, not directories
+          find . -maxdepth 1 -type f ! -name checksums.txt -exec sha256sum {} \; | sed 's|./||' > checksums.txt
           echo "=== Checksums ==="
           cat checksums.txt
 


### PR DESCRIPTION
## Summary

Fix release workflow failing on checksum generation due to macOS .app bundle being a directory.

## Changes

- Added step to zip the macOS .app bundle before checksumming
- Changed checksum command to use `find` to only process files, not directories

## Root Cause

The macOS Wails build creates `secretctl.app` as a directory (application bundle), but `sha256sum *` cannot hash directories.