### PR TITLE
feat: implement import command for .env/JSON files

### DIFF
--- a/cmd/secretctl/import.go
+++ b/cmd/secretctl/import.go
@@ -1,0 +1,535 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/forest6511/secretctl/pkg/vault"
+)
+
+// Import conflict handling modes
+const (
+	conflictSkip      = "skip"
+	conflictOverwrite = "overwrite"
+	conflictError     = "error"
+)
+
+var (
+	importFormat   string
+	importConflict string
+	importDryRun   bool
+	importKeys     []string
+)
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+
+	importCmd.Flags().StringVarP(&importFormat, "format", "f", "", "Input format: env, json (auto-detected if not specified)")
+	importCmd.Flags().StringVar(&importConflict, "conflict", conflictSkip, "Conflict handling: skip, overwrite, error")
+	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Show what would be imported without making changes")
+	importCmd.Flags().StringSliceVarP(&importKeys, "key", "k", nil, "Keys to import (glob pattern supported)")
+
+	// Convenience aliases
+	importCmd.Flags().Bool("skip", false, "Skip existing keys (same as --conflict=skip)")
+	importCmd.Flags().Bool("overwrite", false, "Overwrite existing keys (same as --conflict=overwrite)")
+	importCmd.Flags().Bool("error", false, "Error on conflict (same as --conflict=error)")
+}
+
+var importCmd = &cobra.Command{
+	Use:   "import [file]",
+	Short: "Import secrets from .env or JSON file",
+	Long: `Import secrets from .env or JSON file into the vault.
+
+Examples:
+  # Import from .env file (auto-detected format)
+  secretctl import .env
+
+  # Import from JSON file
+  secretctl import config.json --format=json
+
+  # Import with overwrite mode
+  secretctl import .env --overwrite
+
+  # Preview import without making changes
+  secretctl import .env --dry-run
+
+  # Import specific keys only
+  secretctl import .env -k "AWS_*" -k "DB_*"
+
+Conflict handling:
+  --skip       Skip keys that already exist (default)
+  --overwrite  Overwrite existing keys with new values
+  --error      Exit with error if any key already exists`,
+	Args: cobra.ExactArgs(1),
+	RunE: executeImport,
+}
+
+func executeImport(cmd *cobra.Command, args []string) error {
+	filePath := args[0]
+
+	// Handle convenience flags
+	if skip, _ := cmd.Flags().GetBool("skip"); skip {
+		importConflict = conflictSkip
+	}
+	if overwrite, _ := cmd.Flags().GetBool("overwrite"); overwrite {
+		importConflict = conflictOverwrite
+	}
+	if errFlag, _ := cmd.Flags().GetBool("error"); errFlag {
+		importConflict = conflictError
+	}
+
+	// Validate conflict flag
+	if err := validateImportFlags(); err != nil {
+		return err
+	}
+
+	// Detect format if not specified
+	format, err := detectImportFormat(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Parse the input file
+	secrets, err := parseImportFile(filePath, format)
+	if err != nil {
+		return err
+	}
+
+	if len(secrets) == 0 {
+		fmt.Println("No secrets found in file")
+		return nil
+	}
+
+	// Filter by key patterns if specified
+	if len(importKeys) > 0 {
+		secrets, err = filterImportKeys(secrets, importKeys)
+		if err != nil {
+			return err
+		}
+		if len(secrets) == 0 {
+			return fmt.Errorf("no secrets match the specified key patterns")
+		}
+	}
+
+	// Unlock vault (skip if dry-run and just show what would be imported)
+	if !importDryRun {
+		if err := ensureUnlocked(); err != nil {
+			return err
+		}
+		defer v.Lock()
+	}
+
+	// Process import
+	return processImport(secrets)
+}
+
+func validateImportFlags() error {
+	importConflict = strings.ToLower(importConflict)
+	if importConflict != conflictSkip && importConflict != conflictOverwrite && importConflict != conflictError {
+		return fmt.Errorf("invalid conflict mode '%s': must be 'skip', 'overwrite', or 'error'", importConflict)
+	}
+	return nil
+}
+
+func detectImportFormat(filePath string) (string, error) {
+	if importFormat != "" {
+		format := strings.ToLower(importFormat)
+		if format != formatEnv && format != formatJSON {
+			return "", fmt.Errorf("invalid format '%s': must be '%s' or '%s'", importFormat, formatEnv, formatJSON)
+		}
+		return format, nil
+	}
+
+	// Auto-detect from file extension
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".json":
+		return formatJSON, nil
+	case ".env":
+		return formatEnv, nil
+	default:
+		// Check if filename contains "env" (e.g., ".env.local", "env.production")
+		base := strings.ToLower(filepath.Base(filePath))
+		if strings.Contains(base, "env") {
+			return formatEnv, nil
+		}
+		// Default to env format for extensionless files
+		return formatEnv, nil
+	}
+}
+
+func parseImportFile(filePath string, format string) (map[string]string, error) {
+	// Validate file path
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Check file exists
+	info, err := os.Lstat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("file not found: %s", filePath)
+		}
+		return nil, fmt.Errorf("failed to access file: %w", err)
+	}
+
+	// Security check: reject symlinks
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("security: refusing to read symlink: %s", absPath)
+	}
+
+	// Read file
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	switch format {
+	case formatEnv:
+		return parseEnvFile(data)
+	case formatJSON:
+		return parseJSONFile(data)
+	default:
+		return nil, fmt.Errorf("unsupported format: %s", format)
+	}
+}
+
+// envLineRegex matches KEY=VALUE patterns, supporting quoted values
+var envLineRegex = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_/\-.]*)\s*=\s*(.*)$`)
+
+func parseEnvFile(data []byte) (map[string]string, error) {
+	secrets := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+
+	// Increase buffer size to handle large secrets (1MB max line)
+	const maxLineSize = 1024 * 1024
+	buf := make([]byte, maxLineSize)
+	scanner.Buffer(buf, maxLineSize)
+
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+
+		// Skip empty lines and comments
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Parse KEY=VALUE
+		matches := envLineRegex.FindStringSubmatch(trimmed)
+		if matches == nil {
+			// Skip invalid lines (be lenient)
+			continue
+		}
+
+		key := matches[1]
+		value := matches[2]
+
+		// Handle quoted values
+		value = unquoteEnvValue(value)
+
+		secrets[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	return secrets, nil
+}
+
+func unquoteEnvValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+
+	// Check for quoted strings
+	if (value[0] == '"' && value[len(value)-1] == '"') ||
+		(value[0] == '\'' && value[len(value)-1] == '\'') {
+		quote := value[0]
+		value = value[1 : len(value)-1]
+
+		// Handle escape sequences for double-quoted strings
+		// Process in single pass to avoid ordering issues
+		if quote == '"' {
+			var result strings.Builder
+			result.Grow(len(value))
+			for i := 0; i < len(value); i++ {
+				if value[i] == '\\' && i+1 < len(value) {
+					switch value[i+1] {
+					case '"':
+						result.WriteByte('"')
+						i++
+					case '\\':
+						result.WriteByte('\\')
+						i++
+					case 'n':
+						result.WriteByte('\n')
+						i++
+					case 'r':
+						result.WriteByte('\r')
+						i++
+					case 't':
+						result.WriteByte('\t')
+						i++
+					case '$':
+						result.WriteByte('$')
+						i++
+					default:
+						// Unknown escape - keep as-is
+						result.WriteByte(value[i])
+					}
+				} else {
+					result.WriteByte(value[i])
+				}
+			}
+			value = result.String()
+		}
+	}
+
+	return value
+}
+
+func parseJSONFile(data []byte) (map[string]string, error) {
+	// Try parsing as flat key-value object first
+	var flatMap map[string]interface{}
+	if err := json.Unmarshal(data, &flatMap); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	secrets := make(map[string]string)
+	for key, val := range flatMap {
+		switch v := val.(type) {
+		case string:
+			secrets[key] = v
+		case float64:
+			// Handle numbers
+			secrets[key] = fmt.Sprintf("%v", v)
+		case bool:
+			// Handle booleans
+			secrets[key] = fmt.Sprintf("%v", v)
+		case nil:
+			// Skip null values
+			continue
+		default:
+			// Skip complex types (arrays, nested objects)
+			continue
+		}
+	}
+
+	return secrets, nil
+}
+
+func filterImportKeys(secrets map[string]string, patterns []string) (map[string]string, error) {
+	allKeys := make([]string, 0, len(secrets))
+	for key := range secrets {
+		allKeys = append(allKeys, key)
+	}
+
+	// Get matching keys
+	matchedKeys := make(map[string]bool)
+	for _, pattern := range patterns {
+		matches, err := expandImportPattern(pattern, allKeys)
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range matches {
+			matchedKeys[key] = true
+		}
+	}
+
+	// Filter secrets to only matched keys
+	filtered := make(map[string]string)
+	for key, value := range secrets {
+		if matchedKeys[key] {
+			filtered[key] = value
+		}
+	}
+
+	return filtered, nil
+}
+
+func expandImportPattern(pattern string, availableKeys []string) ([]string, error) {
+	// Validate pattern syntax
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		return nil, fmt.Errorf("invalid pattern '%s': %w", pattern, err)
+	}
+
+	// Check if pattern contains glob characters
+	hasGlob := strings.ContainsAny(pattern, "*?[")
+
+	if !hasGlob {
+		// Exact match - verify key exists
+		for _, key := range availableKeys {
+			if key == pattern {
+				return []string{pattern}, nil
+			}
+		}
+		return nil, fmt.Errorf("key '%s' not found in import file", pattern)
+	}
+
+	// Glob matching
+	var matches []string
+	for _, key := range availableKeys {
+		matched, err := filepath.Match(pattern, key)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matches = append(matches, key)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no keys match pattern '%s' in import file", pattern)
+	}
+
+	return matches, nil
+}
+
+func processImport(secrets map[string]string) error {
+	var imported, skipped, conflicts, failed int
+	var errs []string
+
+	// Get existing keys for conflict detection
+	existingKeys, err := getExistingKeys()
+	if err != nil {
+		return err
+	}
+
+	// Sort keys for consistent output
+	sortedKeys := sortKeys(secrets)
+
+	for _, key := range sortedKeys {
+		value := secrets[key]
+
+		if importDryRun {
+			fmt.Printf("[dry-run] Would import: %s\n", key)
+			imported++
+			continue
+		}
+
+		// Check for conflicts
+		exists := existingKeys[key]
+		action, errMsg := handleConflict(key, exists)
+		switch action {
+		case "skip":
+			skipped++
+			continue
+		case "error":
+			errs = append(errs, errMsg)
+			conflicts++
+			continue
+		}
+
+		// Save secret
+		if err := saveSecret(key, value, exists); err != nil {
+			errs = append(errs, fmt.Sprintf("failed to import '%s': %v", key, err))
+			failed++
+			continue
+		}
+		imported++
+	}
+
+	// Print summary
+	printImportSummary(imported, skipped, conflicts, failed)
+
+	// Return error if any issues
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+func getExistingKeys() (map[string]bool, error) {
+	if importDryRun {
+		return nil, nil
+	}
+	keys, err := v.ListSecrets()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list existing secrets: %w", err)
+	}
+	existingKeys := make(map[string]bool)
+	for _, key := range keys {
+		existingKeys[key] = true
+	}
+	return existingKeys, nil
+}
+
+func sortKeys(secrets map[string]string) []string {
+	sortedKeys := make([]string, 0, len(secrets))
+	for key := range secrets {
+		sortedKeys = append(sortedKeys, key)
+	}
+	for i := 0; i < len(sortedKeys); i++ {
+		for j := i + 1; j < len(sortedKeys); j++ {
+			if sortedKeys[i] > sortedKeys[j] {
+				sortedKeys[i], sortedKeys[j] = sortedKeys[j], sortedKeys[i]
+			}
+		}
+	}
+	return sortedKeys
+}
+
+func handleConflict(key string, exists bool) (action string, errMsg string) {
+	if !exists {
+		return "import", ""
+	}
+	switch importConflict {
+	case conflictSkip:
+		fmt.Printf("Skipped (exists): %s\n", key)
+		return "skip", ""
+	case conflictError:
+		return "error", fmt.Sprintf("key already exists: %s", key)
+	default:
+		return "import", ""
+	}
+}
+
+func saveSecret(key, value string, exists bool) error {
+	entry := &vault.SecretEntry{
+		Value: []byte(value),
+	}
+	if err := v.SetSecret(key, entry); err != nil {
+		return err
+	}
+	if exists {
+		fmt.Printf("Overwritten: %s\n", key)
+	} else {
+		fmt.Printf("Imported: %s\n", key)
+	}
+	return nil
+}
+
+func printImportSummary(imported, skipped, conflicts, failed int) {
+	fmt.Println()
+	if importDryRun {
+		fmt.Printf("Dry-run complete: %d secret(s) would be imported\n", imported)
+		return
+	}
+	fmt.Printf("Import summary: %d imported", imported)
+	if skipped > 0 {
+		fmt.Printf(", %d skipped", skipped)
+	}
+	if conflicts > 0 {
+		fmt.Printf(", %d conflicts", conflicts)
+	}
+	if failed > 0 {
+		fmt.Printf(", %d failed", failed)
+	}
+	fmt.Println()
+}

--- a/cmd/secretctl/import_test.go
+++ b/cmd/secretctl/import_test.go
@@ -1,0 +1,801 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+		wantErr  bool
+	}{
+		{
+			name: "simple key-value pairs",
+			input: `API_KEY=secret123
+DB_HOST=localhost
+DB_PORT=5432`,
+			expected: map[string]string{
+				"API_KEY": "secret123",
+				"DB_HOST": "localhost",
+				"DB_PORT": "5432",
+			},
+		},
+		{
+			name: "with comments and empty lines",
+			input: `# This is a comment
+API_KEY=secret123
+
+# Another comment
+DB_HOST=localhost`,
+			expected: map[string]string{
+				"API_KEY": "secret123",
+				"DB_HOST": "localhost",
+			},
+		},
+		{
+			name: "double quoted values",
+			input: `PASSWORD="my secret password"
+MESSAGE="hello \"world\""`,
+			expected: map[string]string{
+				"PASSWORD": "my secret password",
+				"MESSAGE":  `hello "world"`,
+			},
+		},
+		{
+			name: "single quoted values",
+			input: `PASSWORD='my secret password'
+COMMAND='echo "hello"'`,
+			expected: map[string]string{
+				"PASSWORD": "my secret password",
+				"COMMAND":  `echo "hello"`,
+			},
+		},
+		{
+			name:  "values with equals sign",
+			input: `CONNECTION_STRING=host=localhost;port=5432;user=admin`,
+			expected: map[string]string{
+				"CONNECTION_STRING": "host=localhost;port=5432;user=admin",
+			},
+		},
+		{
+			name:  "escape sequences in double quotes",
+			input: `MULTILINE="line1\nline2\ttab"`,
+			expected: map[string]string{
+				"MULTILINE": "line1\nline2\ttab",
+			},
+		},
+		{
+			name: "keys with special characters",
+			input: `AWS/ACCESS_KEY=AKIAEXAMPLE
+DB.CONNECTION.HOST=localhost
+SERVICE-API-KEY=secret`,
+			expected: map[string]string{
+				"AWS/ACCESS_KEY":     "AKIAEXAMPLE",
+				"DB.CONNECTION.HOST": "localhost",
+				"SERVICE-API-KEY":    "secret",
+			},
+		},
+		{
+			name:     "empty file",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name: "only comments",
+			input: `# comment 1
+# comment 2`,
+			expected: map[string]string{},
+		},
+		{
+			name: "whitespace around equals",
+			input: `KEY1 = value1
+KEY2= value2
+KEY3 =value3`,
+			expected: map[string]string{
+				"KEY1": "value1",
+				"KEY2": "value2",
+				"KEY3": "value3",
+			},
+		},
+		{
+			name: "dollar sign in double quotes",
+			input: `PRICE="$100"
+ESCAPED="\$HOME"`,
+			expected: map[string]string{
+				"PRICE":   "$100",
+				"ESCAPED": "$HOME",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseEnvFile([]byte(tc.input))
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("got %d keys, want %d keys", len(result), len(tc.expected))
+			}
+
+			for key, expectedValue := range tc.expected {
+				actualValue, ok := result[key]
+				if !ok {
+					t.Errorf("missing key: %s", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("key %s: got %q, want %q", key, actualValue, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestParseJSONFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+		wantErr  bool
+	}{
+		{
+			name:  "flat key-value object",
+			input: `{"API_KEY": "secret123", "DB_HOST": "localhost"}`,
+			expected: map[string]string{
+				"API_KEY": "secret123",
+				"DB_HOST": "localhost",
+			},
+		},
+		{
+			name:  "with numbers",
+			input: `{"PORT": 5432, "TIMEOUT": 30.5}`,
+			expected: map[string]string{
+				"PORT":    "5432",
+				"TIMEOUT": "30.5",
+			},
+		},
+		{
+			name:  "with booleans",
+			input: `{"DEBUG": true, "PRODUCTION": false}`,
+			expected: map[string]string{
+				"DEBUG":      "true",
+				"PRODUCTION": "false",
+			},
+		},
+		{
+			name:  "with null values (skipped)",
+			input: `{"API_KEY": "secret", "OPTIONAL": null}`,
+			expected: map[string]string{
+				"API_KEY": "secret",
+			},
+		},
+		{
+			name:  "with nested objects (skipped)",
+			input: `{"API_KEY": "secret", "CONFIG": {"nested": "value"}}`,
+			expected: map[string]string{
+				"API_KEY": "secret",
+			},
+		},
+		{
+			name:  "with arrays (skipped)",
+			input: `{"API_KEY": "secret", "HOSTS": ["host1", "host2"]}`,
+			expected: map[string]string{
+				"API_KEY": "secret",
+			},
+		},
+		{
+			name:     "invalid JSON",
+			input:    `{invalid json}`,
+			wantErr:  true,
+			expected: nil,
+		},
+		{
+			name:     "empty object",
+			input:    `{}`,
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseJSONFile([]byte(tc.input))
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("got %d keys, want %d keys", len(result), len(tc.expected))
+			}
+
+			for key, expectedValue := range tc.expected {
+				actualValue, ok := result[key]
+				if !ok {
+					t.Errorf("missing key: %s", key)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("key %s: got %q, want %q", key, actualValue, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestUnquoteEnvValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unquoted value",
+			input:    "simple",
+			expected: "simple",
+		},
+		{
+			name:     "double quoted",
+			input:    `"hello world"`,
+			expected: "hello world",
+		},
+		{
+			name:     "single quoted",
+			input:    `'hello world'`,
+			expected: "hello world",
+		},
+		{
+			name:     "escaped double quote",
+			input:    `"say \"hello\""`,
+			expected: `say "hello"`,
+		},
+		{
+			name:     "newline escape",
+			input:    `"line1\nline2"`,
+			expected: "line1\nline2",
+		},
+		{
+			name:     "tab escape",
+			input:    `"col1\tcol2"`,
+			expected: "col1\tcol2",
+		},
+		{
+			name:     "backslash escape",
+			input:    `"C:\\Users\\name"`,
+			expected: `C:\Users\name`,
+		},
+		{
+			name:     "dollar escape",
+			input:    `"\$HOME"`,
+			expected: "$HOME",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single character",
+			input:    "a",
+			expected: "a",
+		},
+		{
+			name:     "whitespace trimming",
+			input:    "  value  ",
+			expected: "value",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := unquoteEnvValue(tc.input)
+			if result != tc.expected {
+				t.Errorf("got %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectImportFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		filePath       string
+		explicitFormat string
+		expected       string
+		wantErr        bool
+	}{
+		{
+			name:     "json extension",
+			filePath: "config.json",
+			expected: "json",
+		},
+		{
+			name:     "env extension",
+			filePath: ".env",
+			expected: "env",
+		},
+		{
+			name:     "env.local",
+			filePath: ".env.local",
+			expected: "env",
+		},
+		{
+			name:     "env.production",
+			filePath: "env.production",
+			expected: "env",
+		},
+		{
+			name:     "no extension defaults to env",
+			filePath: "secrets",
+			expected: "env",
+		},
+		{
+			name:           "explicit format overrides",
+			filePath:       "config.json",
+			explicitFormat: "env",
+			expected:       "env",
+		},
+		{
+			name:           "explicit json format",
+			filePath:       ".env",
+			explicitFormat: "json",
+			expected:       "json",
+		},
+		{
+			name:           "invalid explicit format",
+			filePath:       ".env",
+			explicitFormat: "yaml",
+			wantErr:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			importFormat = tc.explicitFormat
+			defer func() { importFormat = "" }()
+
+			result, err := detectImportFormat(tc.filePath)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tc.expected {
+				t.Errorf("got %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestValidateImportFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		conflict string
+		wantErr  bool
+	}{
+		{
+			name:     "valid skip",
+			conflict: "skip",
+			wantErr:  false,
+		},
+		{
+			name:     "valid overwrite",
+			conflict: "overwrite",
+			wantErr:  false,
+		},
+		{
+			name:     "valid error",
+			conflict: "error",
+			wantErr:  false,
+		},
+		{
+			name:     "case insensitive",
+			conflict: "SKIP",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid mode",
+			conflict: "ignore",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			importConflict = tc.conflict
+			defer func() { importConflict = conflictSkip }()
+
+			err := validateImportFlags()
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandImportPattern(t *testing.T) {
+	availableKeys := []string{
+		"AWS_ACCESS_KEY",
+		"AWS_SECRET_KEY",
+		"DB_HOST",
+		"DB_PORT",
+		"DB_PASSWORD",
+		"API_KEY",
+	}
+
+	tests := []struct {
+		name     string
+		pattern  string
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "exact match",
+			pattern:  "API_KEY",
+			expected: []string{"API_KEY"},
+		},
+		{
+			name:     "wildcard prefix",
+			pattern:  "AWS_*",
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY"},
+		},
+		{
+			name:     "wildcard suffix",
+			pattern:  "*_KEY",
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY", "API_KEY"},
+		},
+		{
+			name:     "question mark wildcard",
+			pattern:  "DB_????",
+			expected: []string{"DB_HOST", "DB_PORT"},
+		},
+		{
+			name:     "all keys",
+			pattern:  "*",
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY", "DB_HOST", "DB_PORT", "DB_PASSWORD", "API_KEY"},
+		},
+		{
+			name:    "no match",
+			pattern: "NONEXISTENT_*",
+			wantErr: true,
+		},
+		{
+			name:    "exact match not found",
+			pattern: "NONEXISTENT",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := expandImportPattern(tc.pattern, availableKeys)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("got %d results, want %d", len(result), len(tc.expected))
+			}
+
+			for _, exp := range tc.expected {
+				found := false
+				for _, r := range result {
+					if r == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing expected key: %s", exp)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterImportKeys(t *testing.T) {
+	secrets := map[string]string{
+		"AWS_ACCESS_KEY": "AKIA...",
+		"AWS_SECRET_KEY": "secret",
+		"DB_HOST":        "localhost",
+		"DB_PORT":        "5432",
+		"API_KEY":        "apikey123",
+	}
+
+	tests := []struct {
+		name     string
+		patterns []string
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "single pattern",
+			patterns: []string{"AWS_*"},
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY"},
+		},
+		{
+			name:     "multiple patterns",
+			patterns: []string{"AWS_*", "API_KEY"},
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY", "API_KEY"},
+		},
+		{
+			name:     "overlapping patterns",
+			patterns: []string{"*_KEY", "API_*"},
+			expected: []string{"AWS_ACCESS_KEY", "AWS_SECRET_KEY", "API_KEY"},
+		},
+		{
+			name:     "no match error",
+			patterns: []string{"NONEXISTENT"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := filterImportKeys(secrets, tc.patterns)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("got %d keys, want %d", len(result), len(tc.expected))
+			}
+
+			for _, exp := range tc.expected {
+				if _, ok := result[exp]; !ok {
+					t.Errorf("missing expected key: %s", exp)
+				}
+			}
+		})
+	}
+}
+
+func TestParseImportFile(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+
+	t.Run("env file", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, ".env")
+		content := "API_KEY=secret123\nDB_HOST=localhost"
+		if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		result, err := parseImportFile(filePath, "env")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+
+		if len(result) != 2 {
+			t.Errorf("got %d keys, want 2", len(result))
+		}
+	})
+
+	t.Run("json file", func(t *testing.T) {
+		filePath := filepath.Join(tempDir, "config.json")
+		content := `{"API_KEY": "secret123", "DB_HOST": "localhost"}`
+		if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		result, err := parseImportFile(filePath, "json")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+
+		if len(result) != 2 {
+			t.Errorf("got %d keys, want 2", len(result))
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := parseImportFile(filepath.Join(tempDir, "nonexistent"), "env")
+		if err == nil {
+			t.Error("expected error for nonexistent file")
+		}
+	})
+
+	t.Run("symlink rejection", func(t *testing.T) {
+		realFile := filepath.Join(tempDir, "real.env")
+		symlink := filepath.Join(tempDir, "link.env")
+
+		if err := os.WriteFile(realFile, []byte("KEY=value"), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		if err := os.Symlink(realFile, symlink); err != nil {
+			t.Skip("cannot create symlinks on this system")
+		}
+
+		_, err := parseImportFile(symlink, "env")
+		if err == nil {
+			t.Error("expected error for symlink")
+		}
+	})
+}
+
+func TestImportCmdFlags(t *testing.T) {
+	// Test that all flags are properly registered
+	flags := importCmd.Flags()
+
+	tests := []struct {
+		name      string
+		flagType  string
+		shorthand string
+	}{
+		{"format", "string", "f"},
+		{"conflict", "string", ""},
+		{"dry-run", "bool", ""},
+		{"key", "stringSlice", "k"},
+		{"skip", "bool", ""},
+		{"overwrite", "bool", ""},
+		{"error", "bool", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := flags.Lookup(tc.name)
+			if flag == nil {
+				t.Errorf("flag --%s not found", tc.name)
+				return
+			}
+
+			if tc.shorthand != "" && flag.Shorthand != tc.shorthand {
+				t.Errorf("flag --%s: got shorthand %q, want %q", tc.name, flag.Shorthand, tc.shorthand)
+			}
+		})
+	}
+}
+
+func TestEnvLineRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantKey string
+		wantVal string
+		matches bool
+	}{
+		{
+			name:    "simple",
+			input:   "KEY=value",
+			wantKey: "KEY",
+			wantVal: "value",
+			matches: true,
+		},
+		{
+			name:    "with underscores",
+			input:   "MY_KEY=value",
+			wantKey: "MY_KEY",
+			wantVal: "value",
+			matches: true,
+		},
+		{
+			name:    "with numbers",
+			input:   "KEY123=value",
+			wantKey: "KEY123",
+			wantVal: "value",
+			matches: true,
+		},
+		{
+			name:    "with slashes",
+			input:   "aws/secret/key=value",
+			wantKey: "aws/secret/key",
+			wantVal: "value",
+			matches: true,
+		},
+		{
+			name:    "with dots",
+			input:   "db.connection.host=localhost",
+			wantKey: "db.connection.host",
+			wantVal: "localhost",
+			matches: true,
+		},
+		{
+			name:    "with dashes",
+			input:   "api-key=value",
+			wantKey: "api-key",
+			wantVal: "value",
+			matches: true,
+		},
+		{
+			name:    "empty value",
+			input:   "KEY=",
+			wantKey: "KEY",
+			wantVal: "",
+			matches: true,
+		},
+		{
+			name:    "starts with number (invalid)",
+			input:   "123KEY=value",
+			matches: false,
+		},
+		{
+			name:    "no equals sign",
+			input:   "INVALID",
+			matches: false,
+		},
+		{
+			name:    "comment line",
+			input:   "#KEY=value",
+			matches: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := envLineRegex.FindStringSubmatch(tc.input)
+
+			if tc.matches {
+				if matches == nil {
+					t.Error("expected match, got nil")
+					return
+				}
+				if matches[1] != tc.wantKey {
+					t.Errorf("key: got %q, want %q", matches[1], tc.wantKey)
+				}
+				if matches[2] != tc.wantVal {
+					t.Errorf("value: got %q, want %q", matches[2], tc.wantVal)
+				}
+			} else if matches != nil {
+				t.Errorf("expected no match, got %v", matches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Implements `secretctl import` command to import secrets from .env and JSON files.

Closes #82

## Features
- Support .env and JSON file formats with auto-detection
- Conflict handling options:
  - `--skip` (default): Skip existing keys
  - `--overwrite`: Overwrite existing keys
  - `--error`: Exit with error on conflict
- Dry-run mode (`--dry-run`) to preview imports
- Pattern matching with `-k` flag for selective imports
- Proper escape sequence handling in .env values
- Large file support (1MB line buffer for PEM certs/JWTs)

## Examples
```bash
secretctl import .env
secretctl import config.json --format=json
secretctl import .env --overwrite
secretctl import .env --dry-run
secretctl import .env -k "AWS_*" -k "DB_*"
```

## Test plan
- [x] Unit tests for .env parsing (various formats, quotes, escapes)
- [x] Unit tests for JSON parsing (strings, numbers, booleans)
- [x] Unit tests for pattern matching
- [x] Unit tests for conflict mode validation
- [x] Unit tests for format detection
- [x] All existing tests pass
- [x] Linter passes
- [x] Codex review completed