### PR TITLE
docs: sync documentation with import command and fix website issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`import` command** - Import secrets from .env or JSON files (#91)
+  - Support for `.env` and JSON formats
+  - Conflict handling modes: `--skip`, `--overwrite`, `--error`
+  - Preview mode with `--dry-run`
+  - Import summary with counts
+
+### Fixed
+- **E2E test stability** - Resolved flaky tests AUDIT-002 and CORE-004 (#93)
+  - Fixed strict mode violations in audit table header checks
+  - Fixed custom ConfirmDialog interaction in delete tests
+  - Improved CI workflow timeout handling
+
 ## [0.5.0] - 2025-12-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,25 @@ secretctl export --format=json -k "db/*" -o config.json
 secretctl export --format=json | jq '.DB_HOST'
 ```
 
+### Import Secrets
+
+Import secrets from existing `.env` or JSON files:
+
+```bash
+# Import from .env file
+secretctl import .env
+
+# Import from JSON file
+secretctl import config.json
+
+# Preview what would be imported (dry run)
+secretctl import .env --dry-run
+
+# Handle conflicts: skip, overwrite, or error
+secretctl import .env --on-conflict=skip
+secretctl import .env --on-conflict=overwrite
+```
+
 ### Generate Passwords
 
 Create secure random passwords:

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -28,14 +28,14 @@ sidebar_position: 1
 If you prefer the command line:
 
 ```bash
-# Install
-brew install forest6511/tap/secretctl
+# Download from GitHub Releases
+# https://github.com/forest6511/secretctl/releases
 
 # Initialize vault
 secretctl init
 
 # Add your first secret
-secretctl secret add api/openai --value "sk-..."
+echo "sk-..." | secretctl set OPENAI_API_KEY
 ```
 
 [Continue with CLI Guide →](/docs/guides/cli/)
@@ -58,8 +58,11 @@ If you want to use secretctl with Claude Code or other AI agents:
 {
   "mcpServers": {
     "secretctl": {
-      "command": "secretctl",
-      "args": ["mcp", "serve"]
+      "command": "/path/to/secretctl",
+      "args": ["mcp-server"],
+      "env": {
+        "SECRETCTL_PASSWORD": "your-master-password"
+      }
     }
   }
 }

--- a/website/docs/guides/cli/index.md
+++ b/website/docs/guides/cli/index.md
@@ -8,7 +8,33 @@ sidebar_position: 1
 
 Learn to use secretctl from the command line.
 
-- [Managing Secrets](/docs/guides/cli/managing-secrets)
-- [Running Commands](/docs/guides/cli/running-commands)
-- [Exporting Secrets](/docs/guides/cli/exporting-secrets)
-- [Password Generation](/docs/guides/cli/password-generation)
+## Quick Reference
+
+```bash
+# Initialize vault
+secretctl init
+
+# Manage secrets
+echo "value" | secretctl set KEY
+secretctl get KEY
+secretctl list
+secretctl delete KEY
+
+# Run commands with secrets
+secretctl run -k KEY -- your-command
+
+# Export secrets
+secretctl export -o .env
+
+# Generate passwords
+secretctl generate
+```
+
+## Guides
+
+- [Running Commands](/docs/guides/cli/running-commands) - Execute commands with secrets as environment variables
+- [Password Generation](/docs/guides/cli/password-generation) - Generate secure random passwords
+
+## Reference
+
+For complete command documentation, see the [CLI Commands Reference](/docs/reference/cli-commands).

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -250,6 +250,47 @@ secretctl export -f json | jq '.DB_HOST'
 
 ---
 
+## import
+
+Import secrets from `.env` or JSON files.
+
+```bash
+secretctl import [file] [flags]
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--on-conflict string` | How to handle existing keys: `skip`, `overwrite`, `error` (default: `error`) |
+| `--dry-run` | Preview what would be imported without making changes |
+
+**Examples:**
+
+```bash
+# Import from .env file
+secretctl import .env
+
+# Import from JSON file
+secretctl import config.json
+
+# Preview changes without importing
+secretctl import .env --dry-run
+
+# Skip existing keys
+secretctl import .env --on-conflict=skip
+
+# Overwrite existing keys
+secretctl import .env --on-conflict=overwrite
+```
+
+**Supported Formats:**
+
+- `.env` files: Standard KEY=VALUE format
+- JSON files: Object with key-value pairs `{"KEY": "value"}`
+
+---
+
 ## generate
 
 Generate cryptographically secure random passwords.


### PR DESCRIPTION
## Summary

- Add `import` command documentation to README.md and website CLI reference
- Update CHANGELOG.md [Unreleased] with PR #91 (import) and #93 (E2E fixes)
- Fix website documentation inconsistencies

## Changes

### Documentation Additions
- Added `import` command section to README.md
- Added `import` command documentation to `website/docs/reference/cli-commands.md`

### Bug Fixes
- Fixed incorrect CLI syntax in `website/docs/getting-started/index.md`:
  - Changed `secretctl secret add` to `secretctl set`
  - Changed `secretctl mcp serve` to `secretctl mcp-server`
- Removed non-existent Homebrew installation instructions
- Fixed broken links in `website/docs/guides/cli/index.md` (removed references to non-existent pages)
- Added quick reference section to CLI guide

### CHANGELOG Updates
- Added [Unreleased] section with:
  - PR #91: `import` command feature
  - PR #93: E2E test stability fixes

## Test plan

- [ ] Website builds successfully
- [ ] Documentation links are valid
- [ ] CLI reference matches actual commands