### PR TITLE
chore: update crypto coverage target to 90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
       crypto:
         paths:
           - "pkg/crypto/**"
-        target: 80%
+        target: 90%
         threshold: 2%
         informational: true
       # Critical package: vault (informational until coverage improves)


### PR DESCRIPTION
## Summary
- Update codecov.yml crypto package target from 80% to 90% per project roadmap requirements

## Changes
- `codecov.yml`: crypto target 80% → 90%
- Target is informational (non-blocking) until coverage improves

## Test Plan
- [x] CI passes