### PR TITLE
docs: add dual persona Getting Started guides

### DIFF
--- a/website/docs/getting-started/for-developers.md
+++ b/website/docs/getting-started/for-developers.md
@@ -1,0 +1,196 @@
+---
+title: For Developers
+description: Get started with secretctl for AI-assisted development workflows.
+sidebar_position: 2
+---
+
+# Getting Started: For Developers
+
+This guide is for developers who want to integrate secretctl with AI coding assistants like Claude Code, automate secret injection in CI/CD, or use the MCP server for programmatic access.
+
+## What You'll Learn
+
+- Set up secretctl with Claude Code in 5 minutes
+- Use the MCP server for AI-safe secret access
+- Automate secret injection in your development workflow
+
+## Prerequisites
+
+- macOS, Linux, or Windows
+- Terminal access
+- Claude Code or similar AI coding assistant (optional)
+
+## Step 1: Install secretctl
+
+```bash
+# macOS (Apple Silicon)
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-darwin-arm64
+chmod +x secretctl-darwin-arm64
+sudo mv secretctl-darwin-arm64 /usr/local/bin/secretctl
+
+# macOS (Intel)
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-darwin-amd64
+chmod +x secretctl-darwin-amd64
+sudo mv secretctl-darwin-amd64 /usr/local/bin/secretctl
+
+# Linux (x86_64)
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-linux-amd64
+chmod +x secretctl-linux-amd64
+sudo mv secretctl-linux-amd64 /usr/local/bin/secretctl
+
+# Windows - Download from GitHub Releases
+# https://github.com/forest6511/secretctl/releases/latest/download/secretctl-windows-amd64.exe
+```
+
+Verify installation:
+
+```bash
+secretctl --version
+```
+
+## Step 2: Initialize Your Vault
+
+```bash
+secretctl init
+```
+
+You'll be prompted to create a master password. Choose a strong password - this protects all your secrets.
+
+:::tip Password Requirements
+- Minimum 12 characters
+- Mix of uppercase, lowercase, numbers, and symbols recommended
+:::
+
+## Step 3: Add Your API Keys
+
+```bash
+# OpenAI API key
+echo "sk-proj-..." | secretctl set OPENAI_API_KEY
+
+# AWS credentials
+echo "AKIAIOSFODNN7EXAMPLE" | secretctl set aws/access_key_id
+echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" | secretctl set aws/secret_access_key
+
+# Database credentials
+echo "postgres://user:pass@localhost:5432/db" | secretctl set db/connection_string
+
+# With metadata
+echo "ghp_xxxx" | secretctl set github/token \
+  --notes "Personal access token for CI" \
+  --tags "ci,github" \
+  --expires "2025-12-31"
+```
+
+## Step 4: Configure Claude Code (MCP Integration)
+
+Add to your Claude Code settings (`~/.config/claude-code/settings.json` or VS Code settings):
+
+```json
+{
+  "mcpServers": {
+    "secretctl": {
+      "command": "secretctl",
+      "args": ["mcp-server"],
+      "env": {
+        "SECRETCTL_PASSWORD": "your-master-password"
+      }
+    }
+  }
+}
+```
+
+:::warning Security Note
+The password is read once at startup and immediately cleared from the environment. Consider using a wrapper script or your shell's secure environment variable handling to avoid storing the password in config files.
+:::
+
+## Step 5: Use with Claude Code
+
+Once configured, Claude Code can:
+
+| Capability | Example |
+|------------|---------|
+| List your secrets | "What API keys do I have stored?" |
+| Check if a key exists | "Do I have an OpenAI API key?" |
+| Run commands with secrets | "Deploy to AWS using my credentials" |
+| Get masked values | "Show me my GitHub token (masked)" |
+
+**What Claude Code CANNOT do** (by design):
+- Read plaintext secret values
+- Modify or delete secrets
+- Export your vault
+
+This is the **Option D+** security model - AI agents can use your secrets without ever seeing them.
+
+## Step 6: Run Commands with Secrets
+
+Use `secretctl run` to inject secrets as environment variables:
+
+```bash
+# Run AWS CLI with credentials
+secretctl run -k "aws/*" -- aws s3 ls
+
+# Run with specific keys
+secretctl run -k OPENAI_API_KEY -k ANTHROPIC_API_KEY -- python my_script.py
+
+# Use environment aliases
+secretctl run --env dev -k "db/*" -- ./migrate.sh
+```
+
+## Development Workflow Examples
+
+### CI/CD Integration
+
+```yaml
+# GitHub Actions example
+- name: Deploy
+  env:
+    SECRETCTL_MASTER_PASSWORD: ${{ secrets.SECRETCTL_PASSWORD }}
+  run: |
+    secretctl run -k "aws/*" -- ./deploy.sh
+```
+
+### Local Development
+
+```bash
+# Start your dev server with all API keys
+secretctl run -k "api/*" -- npm run dev
+
+# Or export to .env for frameworks that need it
+secretctl export --format env > .env
+```
+
+### Backup Your Vault
+
+```bash
+# Create encrypted backup
+secretctl backup -o ~/backup/secrets-$(date +%Y%m%d).enc
+
+# Restore when needed
+secretctl restore ~/backup/secrets-20241224.enc --dry-run
+```
+
+## Next Steps
+
+- [MCP Security Model](/docs/guides/mcp/security-model) - Understand how Option D+ keeps your secrets safe
+- [Available MCP Tools](/docs/guides/mcp/available-tools) - Complete MCP tool reference
+- [Environment Aliases](/docs/guides/mcp/env-aliases) - Manage dev/staging/prod environments
+- [CLI Reference](/docs/reference/cli-commands) - Full CLI command documentation
+
+## Troubleshooting
+
+### Claude Code doesn't see secretctl
+
+1. Verify the binary path: `which secretctl`
+2. Use absolute path in config: `/usr/local/bin/secretctl`
+3. Restart Claude Code after config changes
+
+### "vault not initialized" error
+
+Run `secretctl init` first, or check `SECRETCTL_VAULT_DIR` environment variable.
+
+### MCP server connection issues
+
+Check logs:
+```bash
+secretctl mcp-server 2>&1 | head -20
+```

--- a/website/docs/getting-started/for-users.md
+++ b/website/docs/getting-started/for-users.md
@@ -1,0 +1,229 @@
+---
+title: For General Users
+description: Get started with secretctl Desktop App for secure password management.
+sidebar_position: 3
+---
+
+# Getting Started: For General Users
+
+This guide is for users who want a simple, secure way to manage passwords, API keys, and other secrets using the Desktop App or basic CLI commands.
+
+## What You'll Learn
+
+- Install and set up the Desktop App
+- Create your secure vault
+- Add, view, and manage your secrets
+- Keep your credentials organized and safe
+
+## Why secretctl?
+
+- **Completely Local**: Your secrets never leave your computer
+- **No Account Required**: No sign-up, no cloud sync, no subscription
+- **Strong Encryption**: Military-grade AES-256 encryption
+- **Simple Interface**: Easy-to-use desktop application
+
+## Option 1: Desktop App (Recommended)
+
+### Step 1: Download
+
+1. Go to [GitHub Releases](https://github.com/forest6511/secretctl/releases)
+2. Download the file for your system:
+   - **macOS**: `secretctl-desktop-macos.zip`
+   - **Windows**: `secretctl-desktop-windows.exe`
+   - **Linux**: `secretctl-desktop-linux`
+
+### Step 2: Install
+
+**macOS**:
+1. Unzip the downloaded file
+2. Drag the app to your Applications folder
+3. Right-click and select "Open" (first time only, to bypass Gatekeeper)
+
+**Windows**:
+1. Run the installer
+2. Follow the installation wizard
+3. Launch from Start Menu
+
+**Linux**:
+1. Make executable: `chmod +x secretctl-desktop-linux`
+2. Run: `./secretctl-desktop-linux`
+
+### Step 3: Create Your Vault
+
+1. Open the secretctl app
+2. Click "Create New Vault"
+3. Enter a strong master password
+4. Confirm your password
+5. Click "Create"
+
+:::tip Choosing a Master Password
+- Use at least 12 characters
+- Mix letters, numbers, and symbols
+- Consider using a passphrase like "correct-horse-battery-staple"
+- **Write it down** and store it safely - there's no recovery if you forget it!
+:::
+
+### Step 4: Add Your First Secret
+
+1. Click the "+" button or "Add Secret"
+2. Enter a name (e.g., "Gmail Password" or "OPENAI_API_KEY")
+3. Enter the secret value
+4. Optionally add:
+   - **Notes**: Additional information
+   - **URL**: Related website
+   - **Tags**: Categories like "email", "work", "api"
+5. Click "Save"
+
+### Step 5: View and Use Secrets
+
+- **View**: Click on any secret to see details
+- **Copy**: Click the copy icon to copy to clipboard (auto-clears after 30 seconds)
+- **Search**: Use the search bar to find secrets quickly
+- **Filter**: Filter by tags or date
+
+### Step 6: Stay Secure
+
+- The app auto-locks after 15 minutes of inactivity
+- Lock manually: Click the lock icon or use `Cmd+L` (Mac) / `Ctrl+L` (Windows)
+- Always lock before leaving your computer
+
+## Option 2: Command Line (CLI)
+
+If you prefer using the terminal:
+
+### Install
+
+**macOS (Apple Silicon)**:
+```bash
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-darwin-arm64
+chmod +x secretctl-darwin-arm64
+sudo mv secretctl-darwin-arm64 /usr/local/bin/secretctl
+```
+
+**macOS (Intel)**:
+```bash
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-darwin-amd64
+chmod +x secretctl-darwin-amd64
+sudo mv secretctl-darwin-amd64 /usr/local/bin/secretctl
+```
+
+**Linux**:
+```bash
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-linux-amd64
+chmod +x secretctl-linux-amd64
+sudo mv secretctl-linux-amd64 /usr/local/bin/secretctl
+```
+
+**Windows**: Download `secretctl-windows-amd64.exe` from [GitHub Releases](https://github.com/forest6511/secretctl/releases).
+
+### Basic Commands
+
+```bash
+# Create your vault
+secretctl init
+
+# Add a secret
+echo "my-password-123" | secretctl set "Gmail Password"
+
+# View a secret
+secretctl get "Gmail Password"
+
+# List all secrets
+secretctl list
+
+# Delete a secret
+secretctl delete "Gmail Password"
+```
+
+## Organizing Your Secrets
+
+### Use Key Prefixes
+
+Organize secrets by category using prefixes:
+
+```
+email/gmail
+email/outlook
+social/twitter
+social/facebook
+work/github
+work/aws_key
+banking/chase
+```
+
+### Use Tags
+
+Add tags when creating secrets:
+- Desktop: Enter tags in the Tags field
+- CLI: `echo "value" | secretctl set KEY --tags "work,api,important"`
+
+### Add Notes and URLs
+
+Keep track of where each secret is used:
+- Desktop: Fill in the Notes and URL fields
+- CLI: `echo "value" | secretctl set KEY --notes "Main account" --url "https://example.com"`
+
+## Backup Your Secrets
+
+### Create a Backup
+
+**Desktop**: Menu → File → Backup Vault
+
+**CLI**:
+```bash
+secretctl backup -o ~/Desktop/my-secrets-backup.enc
+```
+
+The backup is encrypted with your master password.
+
+### Restore from Backup
+
+**Desktop**: Menu → File → Restore from Backup
+
+**CLI**:
+```bash
+secretctl restore ~/Desktop/my-secrets-backup.enc
+```
+
+## Keyboard Shortcuts (Desktop App)
+
+| Action | macOS | Windows/Linux |
+|--------|-------|---------------|
+| Lock vault | `Cmd+L` | `Ctrl+L` |
+| New secret | `Cmd+N` | `Ctrl+N` |
+| Search | `Cmd+F` | `Ctrl+F` |
+| Copy value | `Cmd+C` | `Ctrl+C` |
+| Quit | `Cmd+Q` | `Ctrl+Q` |
+
+## Frequently Asked Questions
+
+### What if I forget my master password?
+
+Unfortunately, there's no recovery option. The master password is the only way to decrypt your secrets. We recommend:
+- Writing it down and storing it in a safe place
+- Using a memorable passphrase
+
+### Are my secrets synced to the cloud?
+
+No. secretctl is completely local. Your secrets are stored only on your computer in an encrypted file.
+
+### Can I use it on multiple computers?
+
+Yes, but you'll need to manually transfer your vault:
+1. Create a backup on Computer A
+2. Copy the backup file to Computer B
+3. Restore the backup on Computer B
+
+### Is it safe?
+
+Yes. secretctl uses:
+- AES-256-GCM encryption (same as banks and governments)
+- Argon2id key derivation (protects against password cracking)
+- Local-only storage (no network exposure)
+
+## Next Steps
+
+- [Desktop App Guide](/docs/guides/desktop/) - Complete desktop app documentation
+- [CLI Guide](/docs/guides/cli/) - Learn more CLI commands
+- [Security Overview](/docs/security/) - Understand how your data is protected
+- [FAQ](/docs/help/faq) - More frequently asked questions

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -8,6 +8,53 @@ sidebar_position: 1
 
 **secretctl** is the simplest AI-ready secrets manager. It provides secure, local-first credential management with native support for AI agent integration via MCP (Model Context Protocol).
 
+## Choose Your Path
+
+<div className="row">
+  <div className="col col--6">
+    <div className="card" style={{height: '100%'}}>
+      <div className="card__header">
+        <h3>For Developers</h3>
+      </div>
+      <div className="card__body">
+        <p>Integrate with Claude Code, automate CI/CD, use MCP for AI-safe secret access.</p>
+        <ul>
+          <li>MCP server setup</li>
+          <li>Claude Code integration</li>
+          <li>Environment injection</li>
+          <li>API automation</li>
+        </ul>
+      </div>
+      <div className="card__footer">
+        <a className="button button--primary button--block" href="/docs/getting-started/for-developers">
+          Developer Guide →
+        </a>
+      </div>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card" style={{height: '100%'}}>
+      <div className="card__header">
+        <h3>For General Users</h3>
+      </div>
+      <div className="card__body">
+        <p>Simple, secure password management with the Desktop App or basic CLI.</p>
+        <ul>
+          <li>Desktop App setup</li>
+          <li>Password organization</li>
+          <li>Backup and restore</li>
+          <li>No technical knowledge required</li>
+        </ul>
+      </div>
+      <div className="card__footer">
+        <a className="button button--secondary button--block" href="/docs/getting-started/for-users">
+          User Guide →
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Why secretctl?
 
 - **Local-first**: Your secrets never leave your machine
@@ -21,15 +68,23 @@ sidebar_position: 1
 - [Quick Start](/docs/getting-started/quick-start) - Create your first secret in 5 minutes
 - [Core Concepts](/docs/getting-started/concepts) - Understand vaults, secrets, and encryption
 
-## Choose Your Path
+## Quick Start (5 minutes)
 
-### CLI Users
+### Option 1: Desktop App
 
-If you prefer the command line:
+1. Download from [GitHub Releases](https://github.com/forest6511/secretctl/releases)
+2. Open the app and create your vault
+3. Start managing secrets visually
+
+[Continue with Desktop Guide →](/docs/guides/desktop/)
+
+### Option 2: CLI
 
 ```bash
-# Download from GitHub Releases
-# https://github.com/forest6511/secretctl/releases
+# Download and install
+curl -LO https://github.com/forest6511/secretctl/releases/latest/download/secretctl-darwin-arm64
+chmod +x secretctl-darwin-arm64
+sudo mv secretctl-darwin-arm64 /usr/local/bin/secretctl
 
 # Initialize vault
 secretctl init
@@ -40,25 +95,13 @@ echo "sk-..." | secretctl set OPENAI_API_KEY
 
 [Continue with CLI Guide →](/docs/guides/cli/)
 
-### Desktop App Users
-
-If you prefer a graphical interface:
-
-1. Download from [GitHub Releases](https://github.com/forest6511/secretctl/releases)
-2. Open the app and create your vault
-3. Start managing secrets visually
-
-[Continue with Desktop Guide →](/docs/guides/desktop/)
-
-### AI/MCP Integration
-
-If you want to use secretctl with Claude Code or other AI agents:
+### Option 3: AI/MCP Integration
 
 ```json
 {
   "mcpServers": {
     "secretctl": {
-      "command": "/path/to/secretctl",
+      "command": "secretctl",
       "args": ["mcp-server"],
       "env": {
         "SECRETCTL_PASSWORD": "your-master-password"

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -8,6 +8,8 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'getting-started/index',
+        'getting-started/for-developers',
+        'getting-started/for-users',
         'getting-started/installation',
         'getting-started/quick-start',
         'getting-started/concepts',


### PR DESCRIPTION
## Summary
Add separate Getting Started paths for developers and general users per roadmap P2 task.

## Changes

### New Files
- `website/docs/getting-started/for-developers.md` - Developer-focused guide
  - MCP server setup with Claude Code
  - Environment variable injection
  - CI/CD integration examples
  - Backup/restore workflow
  
- `website/docs/getting-started/for-users.md` - General user guide
  - Desktop App installation and setup
  - Basic CLI commands
  - Password organization tips
  - Keyboard shortcuts

### Modified Files
- `website/docs/getting-started/index.md` - Add persona selection cards
- `website/sidebars.ts` - Add new pages to sidebar

### Codex Review Fixes
- Use correct `SECRETCTL_PASSWORD` env var (not `SECRETCTL_MASTER_PASSWORD`)
- Remove non-existent `--password-file` flag reference
- Fix desktop artifact filenames to match release workflow
- Add all platform install instructions (macOS/Linux/Windows)

## Test Plan
- [x] Documentation compiles without errors
- [x] Codex review passed
- [ ] CI checks pass