### PR TITLE
chore: prepare release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-12-24
+
 ### Added
 - **`backup` command** - Create encrypted vault backups (#83)
   - AES-256-GCM encryption with fresh salt per backup

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -85,7 +85,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "secretctl",
-			Version: "0.5.0",
+			Version: "0.6.0",
 		},
 		nil,
 	)


### PR DESCRIPTION
## Release v0.6.0

### Changes
- Update CHANGELOG.md with v0.6.0 release notes  
- Update MCP server version to 0.6.0

### Release Highlights

**New Commands:**
- `backup` - Create encrypted vault backups with AES-256-GCM and HMAC integrity
- `restore` - Atomic restore with conflict handling (skip/overwrite/error)
- `import` - Import secrets from .env or JSON files

**Fixes:**
- E2E test stability improvements

### Post-Merge Steps
After this PR is merged, create the release tag:
```bash
git tag -a v0.6.0 -m "Release v0.6.0"
git push origin v0.6.0
```