### PR TITLE
docs: fill placeholder documentation pages

### DIFF
--- a/website/docs/contributing/development-setup.md
+++ b/website/docs/contributing/development-setup.md
@@ -1,9 +1,227 @@
 ---
 title: Development Setup
-description: Set up your development environment.
+description: Set up your development environment for contributing to secretctl.
 sidebar_position: 2
 ---
 
 # Development Setup
 
-Coming soon.
+This guide helps you set up a development environment for contributing to secretctl.
+
+## Prerequisites
+
+### Required
+
+- **Go 1.24+** - [Download](https://go.dev/dl/)
+- **Git** - For version control
+- **Make** (optional) - For build automation
+
+### For Desktop App Development
+
+- **Node.js 18+** - For frontend development
+- **Wails v2** - [Installation](https://wails.io/docs/gettingstarted/installation)
+
+## Quick Start
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/forest6511/secretctl.git
+cd secretctl
+```
+
+### 2. Install Dependencies
+
+```bash
+# Go dependencies
+go mod download
+
+# Verify the build
+go build ./...
+```
+
+### 3. Run Tests
+
+```bash
+# All tests
+go test ./...
+
+# With race detector
+go test -race ./...
+
+# With coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+```
+
+### 4. Run Linting
+
+```bash
+# Install golangci-lint if needed
+# https://golangci-lint.run/usage/install/
+
+golangci-lint run ./...
+```
+
+## Project Structure
+
+```
+secretctl/
+├── cmd/                    # CLI commands (Cobra)
+│   └── secretctl/
+├── internal/               # Internal packages
+│   ├── cli/               # CLI utilities
+│   ├── config/            # Configuration handling
+│   └── mcp/               # MCP server implementation
+├── pkg/                    # Public packages
+│   ├── audit/             # Audit logging
+│   ├── backup/            # Backup and restore
+│   ├── crypto/            # Cryptographic operations
+│   ├── secret/            # Secret types
+│   └── vault/             # Vault operations
+├── desktop/               # Wails desktop app
+│   ├── frontend/          # React + TypeScript
+│   └── *.go               # Go backend
+└── website/               # Documentation site
+```
+
+## Building
+
+### CLI Binary
+
+```bash
+# Development build
+go build -o bin/secretctl ./cmd/secretctl
+
+# Run locally
+./bin/secretctl --help
+```
+
+### Desktop App
+
+```bash
+cd desktop
+
+# Development mode (hot reload)
+wails dev
+
+# Production build
+wails build
+```
+
+## Development Workflow
+
+### 1. Create a Feature Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+### 2. Make Changes
+
+- Write clear, readable code
+- Follow existing patterns
+- Add tests for new functionality
+- Update documentation as needed
+
+### 3. Test Your Changes
+
+```bash
+# Run all tests
+go test ./...
+
+# Run specific package tests
+go test ./pkg/vault/...
+
+# Run with verbose output
+go test -v ./...
+```
+
+### 4. Lint and Format
+
+```bash
+# Format code
+gofmt -w .
+goimports -w .
+
+# Run linter
+golangci-lint run ./...
+```
+
+### 5. Commit and Push
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```bash
+git add .
+git commit -m "feat: add password strength indicator"
+git push origin feature/your-feature-name
+```
+
+## Testing Tips
+
+### Table-Driven Tests
+
+secretctl uses table-driven tests extensively:
+
+```go
+func TestValidatePassword(t *testing.T) {
+    tests := []struct {
+        name     string
+        password string
+        wantErr  bool
+    }{
+        {"valid", "SecurePass123!", false},
+        {"too short", "short", true},
+        {"empty", "", true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := ValidatePassword(tt.password)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("ValidatePassword() error = %v, wantErr %v", err, tt.wantErr)
+            }
+        })
+    }
+}
+```
+
+### Integration Tests
+
+For tests that need a real vault:
+
+```go
+func TestVaultOperations(t *testing.T) {
+    // Create temp directory
+    tmpDir := t.TempDir()
+
+    // Initialize vault
+    v := vault.New(tmpDir)
+    err := v.Create("test-password-123!")
+    require.NoError(t, err)
+
+    // Your test logic...
+}
+```
+
+## Security Considerations
+
+When contributing security-related code:
+
+- **Never log secrets** - No passwords, keys, or sensitive data in logs
+- **Use crypto/rand** - Never use `math/rand` for security purposes
+- **Wipe sensitive data** - Use `crypto.SecureWipe()` for passwords and keys
+- **Handle errors** - Never ignore errors from crypto operations
+
+## Getting Help
+
+- Read existing code for patterns and conventions
+- Check [issues](https://github.com/forest6511/secretctl/issues) for context
+- Open a [discussion](https://github.com/forest6511/secretctl/discussions) for questions
+
+## Next Steps
+
+- [Contributing Guidelines](/docs/contributing) - Full contribution guide
+- [Architecture Overview](/docs/architecture) - System design
+- [Security Design](/docs/security/encryption) - Cryptographic details

--- a/website/docs/help/troubleshooting.md
+++ b/website/docs/help/troubleshooting.md
@@ -1,9 +1,288 @@
 ---
 title: Troubleshooting
-description: Common issues and solutions.
+description: Common issues and solutions for secretctl.
 sidebar_position: 2
 ---
 
 # Troubleshooting
 
-Coming soon.
+Common issues and their solutions.
+
+## Installation Issues
+
+### "command not found: secretctl"
+
+The binary is not in your PATH.
+
+**Solution:**
+
+```bash
+# Check where you installed it
+ls -la /usr/local/bin/secretctl
+
+# Or add the installation directory to PATH
+export PATH=$PATH:/path/to/secretctl
+```
+
+### Permission denied when running secretctl
+
+The binary doesn't have execute permissions.
+
+**Solution:**
+
+```bash
+chmod +x /usr/local/bin/secretctl
+```
+
+## Vault Issues
+
+### "vault not initialized"
+
+You're trying to use secretctl before creating a vault.
+
+**Solution:**
+
+```bash
+secretctl init
+```
+
+### "vault is locked"
+
+The vault needs to be unlocked before use.
+
+**Solution:**
+
+```bash
+secretctl unlock
+```
+
+### "failed to unlock vault: invalid password"
+
+The password you entered is incorrect.
+
+**Solution:**
+
+- Double-check your password
+- Passwords are case-sensitive
+- If you've forgotten your password, you'll need to restore from a backup
+
+### "vault already exists"
+
+You're trying to initialize a vault that already exists.
+
+**Solution:**
+
+```bash
+# If you want to start fresh (WARNING: destroys existing secrets)
+rm -rf ~/.secretctl
+secretctl init
+
+# Or use a different vault location
+secretctl init --vault-dir=/path/to/new/vault
+```
+
+## MCP Server Issues
+
+### Claude Code doesn't see secretctl
+
+**Check 1:** Verify the binary path
+
+```bash
+which secretctl
+# Should output: /usr/local/bin/secretctl
+```
+
+**Check 2:** Use absolute path in Claude Code config
+
+```json
+{
+  "mcpServers": {
+    "secretctl": {
+      "command": "/usr/local/bin/secretctl",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+**Check 3:** Restart Claude Code after config changes
+
+### "no password provided"
+
+The MCP server needs a password to unlock the vault.
+
+**Solution:**
+
+Set the `SECRETCTL_PASSWORD` environment variable in your Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "secretctl": {
+      "command": "secretctl",
+      "args": ["mcp-server"],
+      "env": {
+        "SECRETCTL_PASSWORD": "your-master-password"
+      }
+    }
+  }
+}
+```
+
+### MCP server connection timeout
+
+The server is taking too long to start.
+
+**Solution:**
+
+1. Test the MCP server manually:
+   ```bash
+   SECRETCTL_PASSWORD=your-password secretctl mcp-server 2>&1 | head -5
+   ```
+
+2. Check for vault issues:
+   ```bash
+   secretctl unlock
+   secretctl list
+   ```
+
+## Desktop App Issues
+
+### App won't start
+
+**macOS:** You may need to allow the app in System Preferences > Security & Privacy.
+
+**Windows:** You may need to allow the app through Windows Defender.
+
+**Linux:** Check if the binary has execute permissions:
+```bash
+chmod +x secretctl-desktop
+```
+
+### "Failed to connect to backend"
+
+The Go backend isn't communicating with the frontend.
+
+**Solution:**
+
+1. Close the app completely
+2. Delete any stale lock files:
+   ```bash
+   rm -f ~/.secretctl/*.lock
+   ```
+3. Restart the app
+
+### Session timeout too aggressive
+
+The app locks after 15 minutes of inactivity by default.
+
+**Solution:**
+
+This is a security feature and cannot be disabled. Keep the app active or unlock when needed.
+
+## Secret Management Issues
+
+### "key already exists"
+
+You're trying to create a secret with a key that already exists.
+
+**Solution:**
+
+```bash
+# Update the existing secret
+echo "new-value" | secretctl set existing-key
+
+# Or delete first, then create
+secretctl delete existing-key
+echo "new-value" | secretctl set existing-key
+```
+
+### Secrets not found in `secretctl run`
+
+The key pattern might not match any secrets.
+
+**Solution:**
+
+```bash
+# List all secrets to see available keys
+secretctl list
+
+# Check your pattern matches
+secretctl list | grep "aws"
+
+# Use correct pattern
+secretctl run -k "aws/*" -- your-command
+```
+
+### Output sanitization removing valid output
+
+The sanitizer detected secret-like patterns in your command output.
+
+**Solution:**
+
+This is a security feature. If you need to see the output without sanitization:
+
+```bash
+# Use the CLI directly (not through MCP)
+secretctl get MY_SECRET
+
+# Or export to a file
+secretctl export --format=env > .env
+```
+
+## Backup & Restore Issues
+
+### "invalid backup file"
+
+The backup file is corrupted or not a valid secretctl backup.
+
+**Solution:**
+
+1. Verify the file exists and has content:
+   ```bash
+   ls -la backup.enc
+   ```
+
+2. Try with `--verify-only` first:
+   ```bash
+   secretctl restore backup.enc --verify-only
+   ```
+
+### "password mismatch" during restore
+
+The password used for restore doesn't match the backup password.
+
+**Solution:**
+
+Use the same password that was used when creating the backup.
+
+## Performance Issues
+
+### Slow vault operations
+
+SQLite database might be fragmented.
+
+**Solution:**
+
+1. Lock the vault
+2. Make a backup
+3. Restore from backup (creates fresh database)
+
+```bash
+secretctl lock
+secretctl backup -o backup.enc
+rm -rf ~/.secretctl
+secretctl restore backup.enc
+```
+
+## Getting More Help
+
+If your issue isn't listed here:
+
+1. Check [GitHub Issues](https://github.com/forest6511/secretctl/issues) for similar problems
+2. Read the [FAQ](/docs/help/faq) for common questions
+3. Open a new issue with:
+   - secretctl version (`secretctl --version`)
+   - Operating system and version
+   - Steps to reproduce
+   - Error messages (with secrets redacted)

--- a/website/docs/migration/from-env-files.md
+++ b/website/docs/migration/from-env-files.md
@@ -6,4 +6,111 @@ sidebar_position: 2
 
 # Migrate from .env Files
 
-Coming soon.
+This guide shows you how to migrate your existing `.env` files to secretctl's encrypted vault.
+
+## Why Migrate?
+
+`.env` files have several security issues:
+
+- **Stored in plaintext** - Anyone with file access can read your secrets
+- **Often committed to git** - Easy to accidentally leak credentials
+- **No access control** - Can't restrict who sees which secrets
+- **No audit trail** - No record of when secrets were accessed or changed
+
+secretctl solves these problems with:
+
+- **AES-256-GCM encryption** - Secrets encrypted at rest
+- **Master password protection** - Only authorized users can decrypt
+- **Audit logging** - Full trail of secret access and modifications
+- **AI-safe design** - Safe to use with Claude Code and other AI tools
+
+## Quick Migration
+
+### Step 1: Initialize Your Vault
+
+If you haven't already:
+
+```bash
+secretctl init
+```
+
+### Step 2: Import Your .env File
+
+```bash
+# Preview what will be imported
+secretctl import .env --dry-run
+
+# Import all secrets
+secretctl import .env
+```
+
+### Step 3: Verify the Import
+
+```bash
+secretctl list
+```
+
+### Step 4: Secure Your Old .env File
+
+Once verified, remove or secure your old `.env` file:
+
+```bash
+# Option 1: Delete the file
+rm .env
+
+# Option 2: Add to .gitignore if you need it for local development
+echo ".env" >> .gitignore
+```
+
+## Handling Conflicts
+
+If you're importing into a vault that already has some secrets:
+
+```bash
+# Skip existing keys (keep vault values)
+secretctl import .env --on-conflict=skip
+
+# Overwrite existing keys (use .env values)
+secretctl import .env --on-conflict=overwrite
+
+# Stop on conflict (default behavior)
+secretctl import .env --on-conflict=error
+```
+
+## Import from JSON
+
+secretctl also supports JSON format:
+
+```bash
+# JSON file with key-value pairs
+# {"API_KEY": "sk-xxx", "DB_PASSWORD": "secret"}
+secretctl import config.json
+```
+
+## Multiple Environment Files
+
+For projects with multiple environments:
+
+```bash
+# Import with environment prefixes
+secretctl import .env.development --dry-run
+secretctl import .env.production --dry-run
+
+# Or import to separate "environments" using key prefixes
+# Rename keys during import by editing the file first
+```
+
+## Working with Your Team
+
+After migration, team members can:
+
+1. Clone the project
+2. Initialize their own vault: `secretctl init`
+3. Import shared secrets (from a secure channel, not git)
+4. Use `secretctl run` to inject secrets into commands
+
+## Next Steps
+
+- [Backup your vault](/docs/guides/cli/backup-restore) - Protect your encrypted secrets
+- [Use with AI tools](/docs/getting-started/for-developers) - Set up Claude Code integration
+- [Export when needed](/docs/reference/cli-commands#export) - Generate `.env` files for legacy tools


### PR DESCRIPTION
## Summary

Fill in three placeholder documentation pages that were showing "Coming soon.":

- **migration/from-env-files.md** - Complete guide for migrating from .env files using the `import` command
- **contributing/development-setup.md** - Development environment setup guide with project structure, build instructions, and testing tips
- **help/troubleshooting.md** - Common issues and solutions covering installation, vault, MCP, desktop app, and backup/restore

## Changes

### New Content
- Migration guide with step-by-step instructions, conflict handling, and JSON import support
- Development setup covering prerequisites, quick start, project structure, build commands, and security considerations
- Troubleshooting guide with categorized issues and solutions

### Fixes
- Updated project structure tree to match current codebase (internal/cli, pkg/backup, pkg/secret)
- Fixed broken internal links (`/docs/contributing/guidelines` → `/docs/contributing`)

## Test Plan

- [ ] Verify documentation site builds correctly
- [ ] Verify all internal links work
- [ ] Verify code examples are accurate