### PR TITLE
docs: fix documentation issues found by Codex review

### DIFF
--- a/website/docs/contributing/index.md
+++ b/website/docs/contributing/index.md
@@ -6,8 +6,77 @@ sidebar_position: 1
 
 # Contributing to secretctl
 
-Thank you for your interest in contributing to secretctl!
+Thank you for your interest in contributing to secretctl! This project is open source and welcomes contributions of all kinds.
+
+## Ways to Contribute
+
+### Report Bugs
+
+Found a bug? Please [open an issue](https://github.com/forest6511/secretctl/issues/new) with:
+- A clear description of the problem
+- Steps to reproduce
+- Expected vs actual behavior
+- Your environment (OS, Go version, secretctl version)
+
+### Suggest Features
+
+Have an idea for a new feature? Open an issue describing:
+- The use case you're trying to solve
+- How the feature would work
+- Any alternatives you've considered
+
+### Submit Code
+
+Ready to contribute code? See the [Development Setup](/docs/contributing/development-setup) guide to get started.
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes with tests
+4. Run `go test ./...` and `golangci-lint run`
+5. Submit a pull request
+
+### Improve Documentation
+
+Documentation improvements are always welcome:
+- Fix typos or clarify confusing sections
+- Add examples or use cases
+- Translate documentation
+
+## Code of Conduct
+
+- Be respectful and constructive
+- Focus on the issue, not the person
+- Help others learn and grow
 
 ## Getting Started
 
 - [Development Setup](/docs/contributing/development-setup) - Set up your development environment
+- [Architecture Overview](/docs/architecture) - Understand the system design
+- [GitHub Issues](https://github.com/forest6511/secretctl/issues) - Find issues to work on
+
+## Pull Request Guidelines
+
+### Before Submitting
+
+- Run all tests: `go test ./...`
+- Run linter: `golangci-lint run`
+- Update documentation if needed
+- Add tests for new functionality
+
+### PR Description
+
+Include:
+- What the change does
+- Why it's needed
+- How to test it
+- Related issue numbers
+
+### Review Process
+
+1. Maintainers will review your PR
+2. Address any feedback
+3. Once approved, maintainers will merge
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](https://github.com/forest6511/secretctl/blob/main/LICENSE).

--- a/website/docs/getting-started/for-users.md
+++ b/website/docs/getting-started/for-users.md
@@ -24,29 +24,27 @@ This guide is for users who want a simple, secure way to manage passwords, API k
 
 ## Option 1: Desktop App (Recommended)
 
-### Step 1: Download
+### Build from Source
 
-1. Go to [GitHub Releases](https://github.com/forest6511/secretctl/releases)
-2. Download the file for your system:
-   - **macOS**: `secretctl-desktop-macos.zip`
-   - **Windows**: `secretctl-desktop-windows.exe`
-   - **Linux**: `secretctl-desktop-linux`
+The desktop app is currently available by building from source. Pre-built binaries will be available in future releases.
 
-### Step 2: Install
+**Requirements**:
+- [Go 1.24+](https://go.dev/dl/)
+- [Node.js 18+](https://nodejs.org/)
+- [Wails v2](https://wails.io/docs/gettingstarted/installation)
 
-**macOS**:
-1. Unzip the downloaded file
-2. Drag the app to your Applications folder
-3. Right-click and select "Open" (first time only, to bypass Gatekeeper)
+**Build Steps**:
 
-**Windows**:
-1. Run the installer
-2. Follow the installation wizard
-3. Launch from Start Menu
+```bash
+# Clone the repository
+git clone https://github.com/forest6511/secretctl.git
+cd secretctl/desktop
 
-**Linux**:
-1. Make executable: `chmod +x secretctl-desktop-linux`
-2. Run: `./secretctl-desktop-linux`
+# Build the app
+wails build
+```
+
+The compiled app will be in `desktop/build/bin/`.
 
 ### Step 3: Create Your Vault
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -54,22 +54,21 @@ sudo mv secretctl /usr/local/bin/
 ## Verify Installation
 
 ```bash
-secretctl version
+secretctl --help
 ```
 
-Expected output:
-
-```
-secretctl version 1.0.0
-```
+You should see the list of available commands.
 
 ## Desktop App
 
-The desktop app is available for macOS, Linux, and Windows:
+The desktop app provides a GUI alternative to the CLI. Currently, you need to build it from source:
 
-1. Download from [GitHub Releases](https://github.com/forest6511/secretctl/releases)
-2. Install the appropriate package for your platform
-3. Launch the app
+```bash
+cd desktop
+wails build
+```
+
+See [Desktop App Guide](/docs/guides/desktop) for details.
 
 ## Next Steps
 

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -23,13 +23,19 @@ Remember your master password! It cannot be recovered if lost.
 ## 2. Add Your First Secret
 
 ```bash
-secretctl secret add api/openai --value "sk-your-api-key"
+echo "sk-your-api-key" | secretctl set api/openai
+```
+
+Or interactively (prompts for value):
+
+```bash
+secretctl set api/openai
 ```
 
 ## 3. Retrieve a Secret
 
 ```bash
-secretctl secret get api/openai
+secretctl get api/openai
 ```
 
 ## 4. Use Secrets in Commands

--- a/website/docs/guides/mcp/available-tools.md
+++ b/website/docs/guides/mcp/available-tools.md
@@ -17,7 +17,7 @@ List all secret keys with metadata. Does **not** return secret values.
 ```json
 {
   "tag": "optional tag filter",
-  "prefix": "optional key prefix filter"
+  "expiring_within": "optional expiration filter (e.g., '7d', '30d')"
 }
 ```
 
@@ -35,8 +35,7 @@ List all secret keys with metadata. Does **not** return secret values.
       "created_at": "2025-01-01T00:00:00Z",
       "updated_at": "2025-06-15T10:30:00Z"
     }
-  ],
-  "total": 1
+  ]
 }
 ```
 

--- a/website/docs/guides/mcp/index.md
+++ b/website/docs/guides/mcp/index.md
@@ -39,7 +39,7 @@ Add to your Claude Code configuration (`~/.claude.json`):
   "mcpServers": {
     "secretctl": {
       "command": "secretctl",
-      "args": ["mcp", "serve"],
+      "args": ["mcp-server"],
       "env": {
         "SECRETCTL_PASSWORD": "your-master-password"
       }

--- a/website/docs/guides/mcp/security-model.md
+++ b/website/docs/guides/mcp/security-model.md
@@ -128,7 +128,7 @@ secretctl's Option D+ design protects against these threat categories:
 |--------|------------|--------|
 | Malicious prompt requests secrets | Tool-level restrictions | ✅ Mitigated |
 | Injected command in `secret_run` | Command allowlist policy | ✅ Mitigated |
-| Encoded secret extraction | Base64/Hex sanitization | ⚠️ Partial |
+| Encoded secret extraction | Not detected (see limitations) | ⚠️ Not Mitigated |
 
 ### 3. Command Execution Risks
 
@@ -149,12 +149,13 @@ secretctl's Option D+ design protects against these threat categories:
 
 ## Sanitization Details
 
+Sanitization uses **exact string matching** to replace secret values in command output.
+
 ### What IS Detected
 
 | Pattern | Example | Replacement |
 |---------|---------|-------------|
 | Exact match | `AKIAIOSFODNN7EXAMPLE` | `[REDACTED:aws/key]` |
-| Base64 encoded | `QUtJQUlPU0ZPRE5ON0VYQU1QTEU=` | `[REDACTED:aws/key:base64]` |
 | In JSON output | `{"key": "secret123"}` | `{"key": "[REDACTED:api/key]"}` |
 | In URLs | `https://api.example.com?token=abc123` | `[REDACTED:api/token]` |
 
@@ -164,8 +165,9 @@ secretctl's Option D+ design protects against these threat categories:
 
 | Pattern | Example | Why Not Detected |
 |---------|---------|------------------|
-| Hex encoding | `414b494149...` | Not implemented |
-| URL encoding | `%41%4B%49%41...` | Not implemented |
+| Base64 encoding | `QUtJQUlPU0ZPRE5ON0VYQU1QTEU=` | Only exact match |
+| Hex encoding | `414b494149...` | Only exact match |
+| URL encoding | `%41%4B%49%41...` | Only exact match |
 | Partial matches | First 10 chars of secret | Only exact match |
 | Case variations | `SECRET123` vs `secret123` | Case-sensitive match |
 | Split output | `SEC` + `RET123` (across lines) | Single-pass detection |

--- a/website/docs/help/faq.md
+++ b/website/docs/help/faq.md
@@ -164,3 +164,22 @@ secretctl init
 ### Audit log shows "chain broken" warning
 
 This indicates the audit log may have been tampered with. While secrets remain secure, you should investigate the cause.
+
+## Roadmap
+
+### What features are planned?
+
+**Phase 2.5 (Multi-Field Secrets)** - Planned for a future release:
+- Store multiple fields per secret (e.g., username + password + host)
+- Pre-defined templates for common secret types (database, API, SSH)
+- Field-level sensitivity control for MCP integration
+
+This feature is not yet implemented. Currently, each secret stores a single value. For complex credentials, you can use key prefixes to group related secrets:
+
+```bash
+echo "db.example.com" | secretctl set db/prod/host
+echo "myuser" | secretctl set db/prod/user
+echo "secret123" | secretctl set db/prod/password
+```
+
+See the [project roadmap](https://github.com/forest6511/secretctl) for the latest development status.

--- a/website/docs/help/troubleshooting.md
+++ b/website/docs/help/troubleshooting.md
@@ -46,16 +46,6 @@ You're trying to use secretctl before creating a vault.
 secretctl init
 ```
 
-### "vault is locked"
-
-The vault needs to be unlocked before use.
-
-**Solution:**
-
-```bash
-secretctl unlock
-```
-
 ### "failed to unlock vault: invalid password"
 
 The password you entered is incorrect.
@@ -142,7 +132,6 @@ The server is taking too long to start.
 
 2. Check for vault issues:
    ```bash
-   secretctl unlock
    secretctl list
    ```
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -552,26 +552,3 @@ allowed_commands:
 ```
 
 See [MCP Integration Guide](/docs/guides/mcp/) for detailed configuration.
-
----
-
-## completion
-
-Generate shell autocompletion scripts.
-
-```bash
-secretctl completion [bash|zsh|fish|powershell]
-```
-
-**Examples:**
-
-```bash
-# Bash
-secretctl completion bash > /etc/bash_completion.d/secretctl
-
-# Zsh
-secretctl completion zsh > "${fpath[1]}/_secretctl"
-
-# Fish
-secretctl completion fish > ~/.config/fish/completions/secretctl.fish
-```


### PR DESCRIPTION
## Summary

- Fix CLI command syntax in quick-start.md (use `echo | secretctl set`)
- Fix installation verification (use `--help` instead of `version`)
- Fix desktop availability messaging (build from source, not prebuilt)
- Fix MCP config args (`mcp-server` instead of `mcp serve`)
- Fix MCP tool schemas (`expiring_within`, remove `total` field)
- Fix sanitization claims (exact match only, no base64/hex)
- Remove non-existent `completion` command from CLI reference
- Remove non-existent `unlock` command from troubleshooting
- Add Phase 2.5 roadmap note to FAQ
- Expand contributing/index.md with full guidelines

## Test plan

- [ ] Verify website builds: `cd website && npm run build`
- [ ] Check documentation accuracy against implementation