### PR TITLE
feat(vault): add multi-field secrets data model (Phase 2.5a)

### DIFF
--- a/claudedocs/multi-field-secrets-proposal.md
+++ b/claudedocs/multi-field-secrets-proposal.md
@@ -1,0 +1,433 @@
+# Multi-Field Secrets 機能拡張提案
+
+## 調査サマリー
+
+### 競合のデータモデル比較
+
+| ツール | アイテム型 | カスタムフィールド | フィールドタイプ |
+|--------|----------|------------------|-----------------|
+| **1Password** | 20+種類 (Login, Database, API Credential, SSH Key等) | あり | Text, Concealed, URL, Date, Menu, Reference |
+| **Bitwarden** | 4種類 (Login, Card, Identity, Secure Note) | あり | Text, Hidden, Boolean, Linked |
+| **KeePass** | 1種類 (Entry) | あり (Custom Strings) | Text only |
+| **HashiCorp Vault** | なし (KV store) | N/A | Nested JSON |
+| **secretctl現状** | なし | なし | 単一値のみ |
+
+Sources:
+- [1Password Item Categories](https://support.1password.com/item-categories/)
+- [1Password Item Fields](https://developer.1password.com/docs/cli/item-fields/)
+- [Bitwarden Custom Fields](https://bitwarden.com/help/custom-fields/)
+- [KeePass Field References](https://keepass.info/help/base/fieldrefs.html)
+
+---
+
+### 1Passwordのアイテム型詳細
+
+| 型 | 主要フィールド |
+|----|--------------|
+| Login | username, password, url, totp |
+| Database | type, server, port, database, username, password |
+| API Credential | username, credential, hostname, type, validFrom, expires |
+| SSH Key | public_key, private_key, passphrase |
+| Server | url, username, password, admin_console_url |
+
+---
+
+### MCP統合の考慮事項
+
+1. **HashiCorp Vault MCP**: Nested JSON構造 `{ "host": "...", "password": "..." }`
+2. **Keeper Secrets Manager MCP**: Search by title, URL, username等
+3. **MCP 2025-06-18仕様**: Structured data対応強化
+
+**Best Practice**:
+- フィールド単位でのアクセス制御
+- 機密フィールド (password等) はOption D+で保護
+- 非機密フィールド (host, port等) はAIに返却可能
+
+---
+
+## 提案: Phase 2.5 (Multi-Field Secrets)
+
+### なぜPhase 3の前に必要か
+
+```
+Phase 0-2 (完了)        Phase 2.5 (新規)         Phase 3+ (将来)
+─────────────────      ─────────────────        ─────────────────
+単一値シークレット  →   マルチフィールド     →   チーム共有
+                        アイテム型                クラウド同期
+
+現状: key=value         提案: key={fields}       将来: shared vault
+```
+
+**理由**:
+1. **ユーザー要求**: DB接続情報など、複数値が必要なユースケースが多い
+2. **競合との差別化**: 1Password/Bitwardenレベルの機能が必要
+3. **MCP強化**: フィールド単位でOption D+を適用可能に
+4. **Phase 3への基盤**: チーム共有時にアイテム型は必須
+
+---
+
+## データモデル拡張
+
+### 現状
+
+```go
+type Secret struct {
+    Key       string    `json:"key"`
+    Value     string    `json:"value"`      // 単一値
+    Notes     string    `json:"notes"`
+    URL       string    `json:"url"`
+    Tags      []string  `json:"tags"`
+    ExpiresAt *time.Time `json:"expiresAt"`
+}
+```
+
+### 提案
+
+```go
+type Secret struct {
+    Key       string            `json:"key"`
+    Type      SecretType        `json:"type"`       // NEW: アイテム型
+    Fields    map[string]Field  `json:"fields"`     // NEW: マルチフィールド
+    Notes     string            `json:"notes"`
+    URL       string            `json:"url"`
+    Tags      []string          `json:"tags"`
+    ExpiresAt *time.Time        `json:"expiresAt"`
+}
+
+type SecretType string
+
+const (
+    SecretTypePassword SecretType = "password"  // 従来互換
+    SecretTypeLogin    SecretType = "login"
+    SecretTypeDatabase SecretType = "database"
+    SecretTypeAPI      SecretType = "api"
+    SecretTypeSSH      SecretType = "ssh"
+    SecretTypeCustom   SecretType = "custom"
+)
+
+type Field struct {
+    Value      string    `json:"value"`
+    Sensitive  bool      `json:"sensitive"`  // true = Option D+で保護
+    Label      string    `json:"label"`      // 表示名
+}
+```
+
+---
+
+## アイテム型定義
+
+### Login (Webサービス認証)
+
+| フィールド | Sensitive | 説明 |
+|-----------|-----------|------|
+| username | false | ユーザー名/Email |
+| password | **true** | パスワード |
+| url | false | ログインURL |
+| totp_secret | **true** | TOTP秘密鍵 |
+
+### Database (データベース接続)
+
+| フィールド | Sensitive | 説明 |
+|-----------|-----------|------|
+| type | false | postgres, mysql, etc. |
+| host | false | ホスト名 |
+| port | false | ポート番号 |
+| database | false | データベース名 |
+| username | false | DB ユーザー名 |
+| password | **true** | DB パスワード |
+| ssl_mode | false | SSL設定 |
+
+### API (API認証)
+
+| フィールド | Sensitive | 説明 |
+|-----------|-----------|------|
+| api_key | **true** | APIキー |
+| api_secret | **true** | APIシークレット |
+| endpoint | false | APIエンドポイント |
+| description | false | 説明 |
+
+### SSH (SSH接続)
+
+| フィールド | Sensitive | 説明 |
+|-----------|-----------|------|
+| host | false | ホスト名 |
+| port | false | ポート (default: 22) |
+| username | false | ユーザー名 |
+| private_key | **true** | 秘密鍵 |
+| passphrase | **true** | パスフレーズ |
+
+### Custom (カスタム)
+
+| フィールド | Sensitive | 説明 |
+|-----------|-----------|------|
+| (任意) | (指定可能) | ユーザー定義 |
+
+---
+
+## MCP拡張 (Option D+ 準拠)
+
+### 既存ツール変更
+
+```
+secret_list()
+  → アイテム型情報を追加
+  → { "key": "db/prod", "type": "database", "tags": [...] }
+
+secret_get_masked(key)
+  → 全フィールドをマスク表示
+  → { "host": "db.example.com", "password": "****5678" }
+
+secret_exists(key)
+  → 変更なし
+```
+
+### 新規ツール
+
+```
+secret_get_field(key, field)
+  → 非Sensitiveフィールドのみ返却
+  → Sensitiveフィールドはエラー or マスク
+
+secret_run_with_fields(key, command, field_mapping)
+  → フィールドを環境変数にマッピング
+  → { "DB_HOST": "host", "DB_PASS": "password" }
+```
+
+### MCP例: PostgreSQL接続
+
+```
+User: "本番DBに接続してテーブル一覧を取得して"
+
+Claude: secret_get_field("db/production", "host")
+        → "db.example.com"  (non-sensitive: OK)
+
+        secret_get_field("db/production", "password")
+        → ERROR: "Field 'password' is sensitive"
+
+        secret_run_with_fields("db/production", "psql -c '\\dt'", {
+            "PGHOST": "host",
+            "PGPORT": "port",
+            "PGDATABASE": "database",
+            "PGUSER": "username",
+            "PGPASSWORD": "password"
+        })
+        → (テーブル一覧が返る、パスワードはAIに見えない)
+```
+
+---
+
+## CLI拡張
+
+```bash
+# アイテム作成
+secretctl set db/prod --type=database
+# → インタラクティブにフィールド入力
+
+secretctl set db/prod --type=database \
+  --field host=db.example.com \
+  --field port=5432 \
+  --field database=myapp \
+  --field username=admin \
+  --field password  # パスワードは標準入力から
+
+# フィールド取得
+secretctl get db/prod              # 全フィールド表示
+secretctl get db/prod --field=host # 特定フィールドのみ
+
+# 環境変数注入
+secretctl run -k db/prod -- psql
+# → PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD を注入
+```
+
+---
+
+## Desktop App UI
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ 🔐 db/production                                    [Edit] [Delete] │
+├─────────────────────────────────────────────────────────────────────┤
+│ Type: Database (PostgreSQL)                                         │
+│                                                                     │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ Connection                                                      │ │
+│ │   Host:     db.example.com                          [Copy]      │ │
+│ │   Port:     5432                                    [Copy]      │ │
+│ │   Database: myapp_prod                              [Copy]      │ │
+│ │   SSL Mode: require                                 [Copy]      │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ Authentication                              🔒 Protected Fields │ │
+│ │   Username: app_user                                [Copy]      │ │
+│ │   Password: ••••••••••••                    [Show] [Copy]       │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│ Tags: [production] [database] [critical]                            │
+│ Notes: Primary production database - handle with care               │
+│                                                                     │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ 📋 Quick Actions                                                │ │
+│ │   [Copy Connection String]  [Export as .env]  [Test Connection] │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│ Created: 2025-01-15  Updated: 2025-12-20  Expires: Never            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 移行戦略
+
+### 既存データの自動変換
+
+```
+現状:
+  Key: "AWS_SECRET_KEY"
+  Value: "sk-xxxxx"
+
+変換後:
+  Key: "AWS_SECRET_KEY"
+  Type: "password"  (デフォルト型)
+  Fields: {
+    "value": { Value: "sk-xxxxx", Sensitive: true }
+  }
+```
+
+### 後方互換性
+
+```bash
+# 従来の使い方（引き続き動作）
+secretctl set MY_SECRET
+secretctl get MY_SECRET
+secretctl run -k MY_SECRET -- cmd
+
+# 新しい使い方
+secretctl set MY_SECRET --type=login --field username=...
+```
+
+---
+
+## 実装フェーズ
+
+### Phase 2.5a: データモデル拡張 (基盤)
+
+| 優先度 | タスク | 工数目安 |
+|--------|--------|---------|
+| P0 | Secret構造体拡張 | S |
+| P0 | SQLiteスキーマ移行 | M |
+| P0 | 既存データ自動変換 | S |
+| P1 | アイテム型定義 (login, database, api, ssh) | S |
+| P1 | フィールドバリデーション | S |
+
+### Phase 2.5b: CLI/MCP拡張
+
+| 優先度 | タスク | 工数目安 |
+|--------|--------|---------|
+| P0 | CLI `set --type --field` 対応 | M |
+| P0 | CLI `get --field` 対応 | S |
+| P1 | MCP `secret_get_field` ツール | M |
+| P1 | MCP `secret_run_with_fields` ツール | M |
+| P2 | 環境変数マッピング自動化 | M |
+
+### Phase 2.5c: Desktop App対応
+
+| 優先度 | タスク | 工数目安 |
+|--------|--------|---------|
+| P0 | アイテム型選択UI | M |
+| P0 | フィールド編集フォーム | L |
+| P1 | フィールドグループ表示 | M |
+| P2 | Quick Actions (接続文字列コピー等) | M |
+
+---
+
+## 更新ロードマップ案
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    secretctl ロードマップ (更新版)                   │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  Phase 0-2: ローカル完結版                       ✅ v0.6.0 完了     │
+│  ─────────────────────────                                          │
+│  - 単一値シークレット管理                                           │
+│  - CLI + MCP + Desktop App                                          │
+│  - Option D+ (AIに平文非公開)                                       │
+│                                                                     │
+│  Phase 2.5: Multi-Field Secrets                  📋 NEW (提案)      │
+│  ──────────────────────────────                                     │
+│  - アイテム型 (login, database, api, ssh, custom)                   │
+│  - マルチフィールド対応                                             │
+│  - フィールド単位のOption D+                                        │
+│  - MCP拡張 (secret_get_field, secret_run_with_fields)              │
+│  - Desktop App UI刷新                                               │
+│                                                                     │
+│  Phase 3: Team Edition                           📋 将来 (変更なし) │
+│  ─────────────────────                                              │
+│  - クラウド同期サービス                                             │
+│  - チームVault共有                                                  │
+│  - 監査ログエンタープライズ拡張                                     │
+│                                                                     │
+│  Phase 4: Enterprise                             📋 将来 (変更なし) │
+│  ───────────────────                                                │
+│  - SSO/SAML/OIDC統合                                                │
+│  - RBAC                                                             │
+│  - コンプライアンス監査ログ                                         │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## PostgreSQL MCPユースケースへの回答
+
+### 質問: 「ClaudeからPostgreSQLに接続したい」
+
+### 回答: Phase 2.5で実現
+
+```bash
+# 1. DB接続情報を保存
+secretctl set db/postgres/dev --type=database \
+  --field type=postgres \
+  --field host=localhost \
+  --field port=5432 \
+  --field database=myapp \
+  --field username=dev_user \
+  --field password  # 標準入力から
+
+# 2. MCPで使用
+# Claude: "開発DBのテーブル一覧を見せて"
+# → secret_run_with_fields("db/postgres/dev", "psql -c '\\dt'", {...})
+# → AIはパスワードを見ずにコマンド実行
+```
+
+### 責務の明確化
+
+```
+secretctl = Secrets Manager (認証情報管理)
+          + Environment Injector (環境変数注入)
+
+          ≠ Database Client (DB操作は外部ツール)
+```
+
+---
+
+## 次のステップ
+
+1. **この提案のレビュー**: 方向性の確認
+2. **Phase 2.5の優先度決定**: P0タスクから着手
+3. **詳細設計**: データモデル、API仕様の確定
+4. **実装開始**: Phase 2.5a (データモデル拡張) から
+
+---
+
+## Sources
+
+- [1Password Item Categories](https://support.1password.com/item-categories/)
+- [1Password Item Fields](https://developer.1password.com/docs/cli/item-fields/)
+- [Bitwarden Custom Fields](https://bitwarden.com/help/custom-fields/)
+- [KeePass Field References](https://keepass.info/help/base/fieldrefs.html)
+- [HashiCorp Vault MCP Server](https://developer.hashicorp.com/vault/docs/mcp-server/overview)
+- [Keeper Secrets Manager MCP](https://docs.keeper.io/en/keeperpam/secrets-manager/integrations/model-context-protocol-mcp-for-ai-agents-node)
+- [Astrix - State of MCP Server Security 2025](https://astrix.security/learn/blog/state-of-mcp-server-security-2025/)
+- [WorkOS - Best Practices for MCP Secrets Management](https://workos.com/guide/best-practices-for-mcp-secrets-management)

--- a/claudedocs/postgresql-mcp-competitive-analysis.md
+++ b/claudedocs/postgresql-mcp-competitive-analysis.md
@@ -1,0 +1,311 @@
+# PostgreSQL MCP Competitive Analysis
+
+## Executive Summary
+
+This analysis examines how competing MCP servers handle database credentials, with focus on PostgreSQL implementations. The goal is to identify best practices for integrating secretctl with database MCP servers while maintaining Option D+ security principles.
+
+**Key Finding**: Most PostgreSQL MCP servers have significant security weaknesses. secretctl's Option D+ design can provide superior security through credential injection without AI exposure.
+
+---
+
+## Industry Statistics (2025)
+
+Source: [Astrix Security Research - State of MCP Server Security 2025](https://astrix.security/learn/blog/state-of-mcp-server-security-2025/)
+
+| Metric | Value | Risk Level |
+|--------|-------|------------|
+| MCP servers requiring credentials | 88% | - |
+| Using static API keys/PATs | 53% | HIGH |
+| Credentials via environment variables | 79% | MEDIUM |
+| Using OAuth (modern delegation) | 8.5% | LOW |
+
+**Critical Issue**: Few MCP clients store server configuration securely. Credentials passed via MCP tools are stored in chat history.
+
+---
+
+## PostgreSQL MCP Server Implementations
+
+### 1. Official Anthropic PostgreSQL MCP
+**Source**: [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential Storage | Connection string in config |
+| Security Model | Basic environment variables |
+| AI Exposure | Connection string visible in config |
+
+**Weakness**: No native secrets management integration.
+
+---
+
+### 2. Postgres MCP Pro (crystaldba)
+**Source**: [crystaldba/postgres-mcp](https://github.com/crystaldba/postgres-mcp)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential Storage | Config or environment variables |
+| Security Features | Read/write access control |
+| AI Exposure | Credentials may pass through LLM |
+
+**Weakness**: Credentials stored in chat history when passed through LLM.
+
+---
+
+### 3. hthuong09/postgres-mcp
+**Source**: [hthuong09/postgres-mcp](https://github.com/hthuong09/postgres-mcp)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential Storage | Environment variables or .env files |
+| Security Features | Passwords stripped from resource URIs |
+| AI Exposure | Reduced but not eliminated |
+
+**Strength**: Passwords automatically removed from URIs.
+**Weakness**: Still relies on environment variable storage.
+
+---
+
+### 4. HenkDz/postgresql-mcp-server
+**Source**: [HenkDz/postgresql-mcp-server](https://github.com/HenkDz/postgresql-mcp-server)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential Storage | CLI args, env vars, or per-tool config |
+| Security Features | SQL injection prevention, parameterized queries |
+| AI Exposure | Flexible but still exposed |
+
+**Strength**: SQL injection prevention.
+**Weakness**: Multiple credential paths increase attack surface.
+
+---
+
+### 5. 1Password-enabled MySQL MCP Server
+**Source**: [chrisdail/mcp-mysql-1password-server](https://lobehub.com/mcp/chrisdail-mcp-mysql-1password-server)
+
+| Aspect | Implementation |
+|--------|----------------|
+| Credential Storage | 1Password vault |
+| Security Features | AI never sees passwords |
+| AI Exposure | **NONE** - credentials injected at runtime |
+
+**Strength**: Best-in-class security model. Credentials stored in 1Password, injected at runtime, AI model never sees passwords.
+
+---
+
+## Best Practices Summary
+
+Source: [WorkOS Guide - Best Practices for MCP Secrets Management](https://workos.com/guide/best-practices-for-mcp-secrets-management)
+
+### 1. Ephemeral/Dynamic Credentials
+```
+Create temporary credentials valid for 5 minutes
+Execute query with limited permissions
+Automatically terminate access after use
+```
+
+### 2. Per-Tool-Call Connections
+```
+Create connection for each tool call (not on server start)
+Allows tool listing even if not configured
+Trades latency for security and reliability
+```
+
+### 3. Least Privilege Access
+```
+Fine-grained roles per MCP integration
+Avoid "root" tokens
+Read-only permissions where possible
+```
+
+### 4. Enterprise Secret Management
+```
+HashiCorp Vault, AWS Secrets Manager, Azure Key Vault
+Strict access controls and audit logging
+Encryption at rest and in transit
+```
+
+---
+
+## 1Password's Approach
+
+Source: [1Password Blog - Securing MCP Servers](https://1password.com/blog/securing-mcp-servers-with-1password-stop-credential-exposure-in-your-agent)
+
+### `op run` Credential Injection
+
+```bash
+# Instead of hardcoding in config:
+{
+  "env": {
+    "POSTGRES_URL": "postgres://user:password@host/db"  # BAD
+  }
+}
+
+# Use 1Password reference:
+{
+  "env": {
+    "POSTGRES_URL": "op://vault/item/field"  # GOOD
+  }
+}
+```
+
+**How it works**:
+1. `op run` resolves `op://` references
+2. Decrypts secrets in memory
+3. Sets as environment variables for that process
+4. Secrets disappear when process exits
+
+### Security Principles
+- Credentials should NOT be exchanged over non-deterministic AI channels
+- Credentials should be injected on behalf of agent, without handing them over
+- Human users should authorize access to sensitive data
+
+---
+
+## secretctl Integration Design Options
+
+### Option A: secretctl as Credential Injector for Existing PostgreSQL MCP
+
+```
+┌─────────────┐     ┌─────────────┐     ┌──────────────┐
+│ Claude Code │────▶│  secretctl  │────▶│ postgres-mcp │
+│   (AI)      │     │   run       │     │   (Query)    │
+└─────────────┘     └─────────────┘     └──────────────┘
+                          │
+                    Inject env vars
+                    (AI never sees)
+```
+
+**Implementation**:
+```bash
+# secretctl stores PostgreSQL credentials
+secretctl set POSTGRES_URL
+
+# Launch postgres-mcp with injected credentials
+secretctl run -k "POSTGRES_*" -- npx @anthropic/postgres-mcp
+```
+
+**Pros**: Uses existing postgres-mcp, minimal development
+**Cons**: Requires process wrapping, two-tool setup
+
+---
+
+### Option B: secretctl with Database Connection Tools
+
+```
+┌─────────────┐     ┌─────────────────────────────────┐
+│ Claude Code │────▶│          secretctl MCP          │
+│   (AI)      │     │  ┌───────────┐ ┌─────────────┐  │
+└─────────────┘     │  │ secret_*  │ │ db_query    │  │
+                    │  │ (vault)   │ │ db_execute  │  │
+                    │  └───────────┘ └─────────────┘  │
+                    └─────────────────────────────────┘
+                              │
+                         Internal credential
+                         resolution (no exposure)
+```
+
+**New MCP Tools**:
+- `db_query(connection_name, sql)` - Execute SELECT
+- `db_execute(connection_name, sql)` - Execute INSERT/UPDATE/DELETE
+- `db_list_connections()` - List configured database connections
+
+**Pros**: Single tool, integrated experience
+**Cons**: Significant development, scope expansion
+
+---
+
+### Option C: secretctl + Dedicated DB MCP (Recommended)
+
+```
+┌─────────────┐
+│ Claude Code │
+│   (AI)      │
+└──────┬──────┘
+       │
+       ├────────────────────────────────────┐
+       │                                    │
+       ▼                                    ▼
+┌─────────────────┐              ┌─────────────────┐
+│  secretctl MCP  │              │  postgres-mcp   │
+│  (credentials)  │──inject──▶   │  (operations)   │
+└─────────────────┘              └─────────────────┘
+       │
+  Option D+
+  (AI never sees
+   plaintext)
+```
+
+**Workflow**:
+1. secretctl stores database credentials securely
+2. User configures postgres-mcp to read from secretctl
+3. AI uses postgres-mcp for queries
+4. Credentials flow through environment injection, never through AI
+
+**Implementation**: Create launcher script or config pattern
+
+---
+
+## Recommendation
+
+### For secretctl v1.x (Short-term)
+
+**Approach**: Document the `secret_run` pattern for database MCP servers
+
+```bash
+# Store credentials
+echo "postgres://user:pass@host:5432/db" | secretctl set db/postgres/dev
+
+# Launch postgres-mcp with injected credentials
+secretctl run -k "db/postgres/dev" -e POSTGRES_URL -- npx @anthropic/postgres-mcp
+```
+
+**Deliverables**:
+- Documentation: "Using secretctl with Database MCP Servers"
+- Example configurations for common setups
+- Best practices guide
+
+### For secretctl v2.x (Long-term)
+
+**Approach**: Native integration with popular database MCP servers
+
+Potential features:
+- `secretctl mcp-launch postgres` - Launcher command with auto-injection
+- Connection profile management (`secretctl db add`, `secretctl db list`)
+- Integration with 1Password-style `op://` reference syntax
+
+---
+
+## Security Comparison Matrix
+
+| Feature | Raw Config | Env Vars | 1Password | secretctl |
+|---------|-----------|----------|-----------|-----------|
+| Credential Storage | Plaintext | Plaintext | Encrypted | Encrypted |
+| AI Exposure | YES | Possible | NO | NO |
+| Audit Trail | NO | NO | YES | YES |
+| Auto-Rotation | NO | NO | Manual | Manual |
+| Ephemeral Creds | NO | NO | NO | Possible |
+| MCP Integration | Native | Native | `op run` | `secret_run` |
+
+---
+
+## Conclusion
+
+secretctl's Option D+ design aligns with industry best practices (1Password, HashiCorp Vault) for AI-era credential management. The key insight from competitive analysis:
+
+> **Credentials should be injected on behalf of the agent, without handing them over.**
+
+secretctl can achieve this through the existing `secret_run` command, positioning it as the "1Password for developers" in the MCP ecosystem.
+
+---
+
+## Sources
+
+- [Astrix Security - State of MCP Server Security 2025](https://astrix.security/learn/blog/state-of-mcp-server-security-2025/)
+- [WorkOS - Best Practices for MCP Secrets Management](https://workos.com/guide/best-practices-for-mcp-secrets-management)
+- [1Password - Securing MCP Servers](https://1password.com/blog/securing-mcp-servers-with-1password-stop-credential-exposure-in-your-agent)
+- [1Password - Where MCP Fits and Where It Doesn't](https://1password.com/blog/where-mcp-fits-and-where-it-doesnt)
+- [Infisical - Managing Secrets in MCP Servers](https://infisical.com/blog/managing-secrets-mcp-servers)
+- [Docker - Top 5 MCP Server Best Practices](https://www.docker.com/blog/mcp-server-best-practices/)
+- [crystaldba/postgres-mcp](https://github.com/crystaldba/postgres-mcp)
+- [hthuong09/postgres-mcp](https://github.com/hthuong09/postgres-mcp)
+- [HenkDz/postgresql-mcp-server](https://github.com/HenkDz/postgresql-mcp-server)

--- a/pkg/vault/field.go
+++ b/pkg/vault/field.go
@@ -1,0 +1,274 @@
+// Package vault provides secure secret storage with AES-256-GCM encryption.
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Field constants per ADR-002
+const (
+	MaxFieldNameLength = 64          // Maximum field name length
+	MinFieldNameLength = 1           // Minimum field name length
+	MaxFieldValueSize  = 1024 * 1024 // 1 MB maximum field value size
+	MaxAliasCount      = 10          // Maximum number of aliases per field
+	MaxAliasLength     = 64          // Maximum alias length
+	MaxHintLength      = 256         // Maximum hint length
+	MaxKindLength      = 64          // Maximum kind length
+	MaxFieldCount      = 100         // Maximum number of fields per secret
+	MaxBindingCount    = 100         // Maximum number of bindings per secret
+
+	// DefaultFieldName is the field name used for backward compatibility
+	// with single-value secrets
+	DefaultFieldName = "value"
+)
+
+// Field validation errors
+var (
+	ErrFieldNameTooLong     = errors.New("vault: field name too long")
+	ErrFieldNameTooShort    = errors.New("vault: field name too short")
+	ErrFieldNameInvalid     = errors.New("vault: field name must be snake_case (lowercase letters, numbers, underscores)")
+	ErrFieldValueTooLarge   = errors.New("vault: field value too large")
+	ErrTooManyFields        = errors.New("vault: too many fields")
+	ErrTooManyAliases       = errors.New("vault: too many aliases")
+	ErrAliasInvalid         = errors.New("vault: alias must be snake_case")
+	ErrAliasTooLong         = errors.New("vault: alias too long")
+	ErrHintTooLong          = errors.New("vault: hint too long")
+	ErrKindTooLong          = errors.New("vault: kind too long")
+	ErrTooManyBindings      = errors.New("vault: too many bindings")
+	ErrBindingFieldNotFound = errors.New("vault: binding references non-existent field")
+	ErrBindingConflict      = errors.New("vault: multiple bindings map to same environment variable")
+	ErrAliasConflict        = errors.New("vault: alias conflicts with another field name or alias")
+	ErrFieldNotFound        = errors.New("vault: field not found")
+	ErrFieldSensitive       = errors.New("vault: field is marked as sensitive")
+)
+
+// Field represents a single field within a multi-field secret.
+// Per ADR-002: Schema-less design with well-known field names.
+type Field struct {
+	// Value is the actual secret value for this field.
+	Value string `json:"value"`
+
+	// Sensitive indicates whether this field contains sensitive data.
+	// When true, the field cannot be retrieved via MCP secret_get_field.
+	// Default is true for security.
+	Sensitive bool `json:"sensitive"`
+
+	// Aliases are alternative names for this field.
+	// Used for compatibility (e.g., "pwd" -> "password").
+	// Alias resolution is case-insensitive.
+	Aliases []string `json:"aliases,omitempty"`
+
+	// Kind is reserved for Phase 3 schema validation.
+	// Examples: "password", "url", "port", "hostname"
+	Kind string `json:"kind,omitempty"`
+
+	// Hint provides UI/AI description for this field.
+	// Not encrypted, visible to AI agents.
+	Hint string `json:"hint,omitempty"`
+}
+
+// fieldNameRegex validates field names: lowercase letters, numbers, underscores only (snake_case)
+var fieldNameRegex = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// ValidateFieldName validates a field name per ADR-002 naming rules.
+// Field names must be:
+// - 1-64 characters
+// - snake_case format (lowercase letters, numbers, underscores)
+// - Start with a lowercase letter
+func ValidateFieldName(name string) error {
+	if len(name) < MinFieldNameLength {
+		return ErrFieldNameTooShort
+	}
+	if len(name) > MaxFieldNameLength {
+		return ErrFieldNameTooLong
+	}
+	if !fieldNameRegex.MatchString(name) {
+		return fmt.Errorf("%w: got %q", ErrFieldNameInvalid, name)
+	}
+	return nil
+}
+
+// ValidateField validates a single field's properties.
+func ValidateField(name string, field *Field) error {
+	// Validate field name
+	if err := ValidateFieldName(name); err != nil {
+		return err
+	}
+
+	// Validate value size
+	if len(field.Value) > MaxFieldValueSize {
+		return fmt.Errorf("%w: field %q exceeds %d bytes", ErrFieldValueTooLarge, name, MaxFieldValueSize)
+	}
+
+	// Validate aliases
+	if len(field.Aliases) > MaxAliasCount {
+		return fmt.Errorf("%w: field %q has %d aliases (max %d)", ErrTooManyAliases, name, len(field.Aliases), MaxAliasCount)
+	}
+	for _, alias := range field.Aliases {
+		if len(alias) > MaxAliasLength {
+			return fmt.Errorf("%w: %q", ErrAliasTooLong, alias)
+		}
+		// Aliases follow the same naming rules as field names
+		if !fieldNameRegex.MatchString(strings.ToLower(alias)) {
+			return fmt.Errorf("%w: %q", ErrAliasInvalid, alias)
+		}
+	}
+
+	// Validate hint
+	if len(field.Hint) > MaxHintLength {
+		return fmt.Errorf("%w: field %q hint exceeds %d characters", ErrHintTooLong, name, MaxHintLength)
+	}
+
+	// Validate kind (Phase 3 reserved, but validate length)
+	if len(field.Kind) > MaxKindLength {
+		return fmt.Errorf("%w: field %q kind exceeds %d characters", ErrKindTooLong, name, MaxKindLength)
+	}
+
+	return nil
+}
+
+// ValidateFields validates all fields in a multi-field secret.
+// Checks for:
+// - Maximum field count
+// - Individual field validation
+// - Alias conflicts (no alias should match another field name or alias)
+func ValidateFields(fields map[string]Field) error {
+	if len(fields) > MaxFieldCount {
+		return fmt.Errorf("%w: has %d fields (max %d)", ErrTooManyFields, len(fields), MaxFieldCount)
+	}
+
+	// Build a set of all names and aliases to detect conflicts
+	allNames := make(map[string]string) // lowercase name/alias -> original field name
+
+	for name, field := range fields {
+		// Validate individual field
+		if err := ValidateField(name, &field); err != nil {
+			return err
+		}
+
+		// Check field name doesn't conflict
+		lowerName := strings.ToLower(name)
+		if existing, ok := allNames[lowerName]; ok {
+			return fmt.Errorf("%w: %q conflicts with field %q", ErrAliasConflict, name, existing)
+		}
+		allNames[lowerName] = name
+
+		// Check aliases don't conflict
+		for _, alias := range field.Aliases {
+			lowerAlias := strings.ToLower(alias)
+			if existing, ok := allNames[lowerAlias]; ok {
+				return fmt.Errorf("%w: alias %q in field %q conflicts with %q", ErrAliasConflict, alias, name, existing)
+			}
+			allNames[lowerAlias] = name
+		}
+	}
+
+	return nil
+}
+
+// ValidateBindings validates environment variable bindings.
+// Checks for:
+// - Maximum binding count
+// - All referenced fields exist
+// - No duplicate environment variable names
+func ValidateBindings(bindings map[string]string, fields map[string]Field) error {
+	if len(bindings) > MaxBindingCount {
+		return fmt.Errorf("%w: has %d bindings (max %d)", ErrTooManyBindings, len(bindings), MaxBindingCount)
+	}
+
+	// Build lowercase field name set for lookup (including aliases)
+	fieldLookup := make(map[string]bool)
+	for name, field := range fields {
+		fieldLookup[strings.ToLower(name)] = true
+		for _, alias := range field.Aliases {
+			fieldLookup[strings.ToLower(alias)] = true
+		}
+	}
+
+	// Track environment variable names to detect conflicts
+	envVars := make(map[string]string) // uppercase env var -> field name
+
+	for envVar, fieldName := range bindings {
+		// Check field exists
+		if !fieldLookup[strings.ToLower(fieldName)] {
+			return fmt.Errorf("%w: %q references field %q", ErrBindingFieldNotFound, envVar, fieldName)
+		}
+
+		// Check for environment variable conflicts (case-insensitive)
+		upperEnv := strings.ToUpper(envVar)
+		if existing, ok := envVars[upperEnv]; ok {
+			return fmt.Errorf("%w: %q and %q both map to %q", ErrBindingConflict, existing, fieldName, upperEnv)
+		}
+		envVars[upperEnv] = fieldName
+	}
+
+	return nil
+}
+
+// ResolveFieldName resolves a field name, checking aliases if the exact name is not found.
+// Resolution is case-insensitive for aliases.
+// Returns the canonical field name and a copy of the Field, or an error if not found.
+// NOTE: The returned Field is a copy. Modifications to it will NOT affect the original map.
+func ResolveFieldName(fields map[string]Field, name string) (string, *Field, error) {
+	// Try exact match first
+	if field, ok := fields[name]; ok {
+		return name, &field, nil
+	}
+
+	// Try case-insensitive match on field names
+	for fieldName, field := range fields {
+		if strings.EqualFold(fieldName, name) {
+			return fieldName, &field, nil
+		}
+
+		// Check aliases (case-insensitive)
+		for _, alias := range field.Aliases {
+			if strings.EqualFold(alias, name) {
+				return fieldName, &field, nil
+			}
+		}
+	}
+
+	return "", nil, ErrFieldNotFound
+}
+
+// NewDefaultField creates a new Field with default settings (sensitive=true).
+func NewDefaultField(value string) Field {
+	return Field{
+		Value:     value,
+		Sensitive: true,
+	}
+}
+
+// ConvertSingleValueToFields converts a single value to the multi-field format.
+// This is used for backward compatibility with legacy single-value secrets.
+func ConvertSingleValueToFields(value []byte) map[string]Field {
+	return map[string]Field{
+		DefaultFieldName: {
+			Value:     string(value),
+			Sensitive: true,
+		},
+	}
+}
+
+// GetDefaultFieldValue extracts the default "value" field from a Fields map.
+// Returns empty string if not found. Used for backward compatibility.
+func GetDefaultFieldValue(fields map[string]Field) string {
+	if field, ok := fields[DefaultFieldName]; ok {
+		return field.Value
+	}
+	return ""
+}
+
+// IsSingleFieldSecret returns true if the secret has only the default "value" field.
+// Used to detect legacy-format secrets for backward-compatible display.
+func IsSingleFieldSecret(fields map[string]Field) bool {
+	if len(fields) != 1 {
+		return false
+	}
+	_, ok := fields[DefaultFieldName]
+	return ok
+}

--- a/pkg/vault/field_test.go
+++ b/pkg/vault/field_test.go
@@ -1,0 +1,579 @@
+// Package vault provides secure secret storage with AES-256-GCM encryption.
+package vault
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateFieldName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		// Valid names
+		{"valid simple", "password", nil},
+		{"valid with underscore", "api_key", nil},
+		{"valid with number", "key1", nil},
+		{"valid complex", "aws_access_key_id", nil},
+		{"valid single char", "a", nil},
+		{"valid max length", strings.Repeat("a", MaxFieldNameLength), nil},
+
+		// Invalid: too short
+		{"empty string", "", ErrFieldNameTooShort},
+
+		// Invalid: too long
+		{"too long", strings.Repeat("a", MaxFieldNameLength+1), ErrFieldNameTooLong},
+
+		// Invalid: not snake_case
+		{"uppercase", "Password", ErrFieldNameInvalid},
+		{"camelCase", "apiKey", ErrFieldNameInvalid},
+		{"starts with number", "1password", ErrFieldNameInvalid},
+		{"starts with underscore", "_key", ErrFieldNameInvalid},
+		{"contains hyphen", "api-key", ErrFieldNameInvalid},
+		{"contains space", "api key", ErrFieldNameInvalid},
+		{"contains special", "api@key", ErrFieldNameInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFieldName(tt.input)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("ValidateFieldName(%q) = %v, want nil", tt.input, err)
+				}
+			} else {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ValidateFieldName(%q) = %v, want %v", tt.input, err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateField(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		field     *Field
+		wantErr   error
+	}{
+		// Valid fields
+		{
+			name:      "valid simple field",
+			fieldName: "password",
+			field:     &Field{Value: "secret123", Sensitive: true},
+			wantErr:   nil,
+		},
+		{
+			name:      "valid field with aliases",
+			fieldName: "password",
+			field:     &Field{Value: "secret", Sensitive: true, Aliases: []string{"pwd", "pass"}},
+			wantErr:   nil,
+		},
+		{
+			name:      "valid field with hint",
+			fieldName: "api_key",
+			field:     &Field{Value: "key", Hint: "AWS API key for production"},
+			wantErr:   nil,
+		},
+		{
+			name:      "valid field with kind",
+			fieldName: "port",
+			field:     &Field{Value: "8080", Kind: "port"},
+			wantErr:   nil,
+		},
+		{
+			name:      "valid non-sensitive field",
+			fieldName: "username",
+			field:     &Field{Value: "admin", Sensitive: false},
+			wantErr:   nil,
+		},
+
+		// Invalid field name
+		{
+			name:      "invalid field name",
+			fieldName: "InvalidName",
+			field:     &Field{Value: "test"},
+			wantErr:   ErrFieldNameInvalid,
+		},
+
+		// Value too large
+		{
+			name:      "value too large",
+			fieldName: "data",
+			field:     &Field{Value: strings.Repeat("x", MaxFieldValueSize+1)},
+			wantErr:   ErrFieldValueTooLarge,
+		},
+
+		// Too many aliases
+		{
+			name:      "too many aliases",
+			fieldName: "password",
+			field: &Field{
+				Value:   "test",
+				Aliases: make([]string, MaxAliasCount+1),
+			},
+			wantErr: ErrTooManyAliases,
+		},
+
+		// Alias too long
+		{
+			name:      "alias too long",
+			fieldName: "password",
+			field: &Field{
+				Value:   "test",
+				Aliases: []string{strings.Repeat("a", MaxAliasLength+1)},
+			},
+			wantErr: ErrAliasTooLong,
+		},
+
+		// Invalid alias format
+		{
+			name:      "invalid alias format",
+			fieldName: "password",
+			field: &Field{
+				Value:   "test",
+				Aliases: []string{"Invalid-Alias"},
+			},
+			wantErr: ErrAliasInvalid,
+		},
+
+		// Hint too long
+		{
+			name:      "hint too long",
+			fieldName: "api_key",
+			field: &Field{
+				Value: "test",
+				Hint:  strings.Repeat("x", MaxHintLength+1),
+			},
+			wantErr: ErrHintTooLong,
+		},
+
+		// Kind too long
+		{
+			name:      "kind too long",
+			fieldName: "data",
+			field: &Field{
+				Value: "test",
+				Kind:  strings.Repeat("x", MaxKindLength+1),
+			},
+			wantErr: ErrKindTooLong,
+		},
+	}
+
+	// Initialize aliases for "too many aliases" test
+	for i := range tests {
+		if tests[i].name == "too many aliases" {
+			for j := range tests[i].field.Aliases {
+				tests[i].field.Aliases[j] = "alias" + string(rune('a'+j%26))
+			}
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateField(tt.fieldName, tt.field)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("ValidateField(%q) = %v, want nil", tt.fieldName, err)
+				}
+			} else {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ValidateField(%q) = %v, want %v", tt.fieldName, err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		fields  map[string]Field
+		wantErr error
+	}{
+		// Valid cases
+		{
+			name: "single field",
+			fields: map[string]Field{
+				"password": {Value: "secret", Sensitive: true},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "multiple fields",
+			fields: map[string]Field{
+				"username": {Value: "admin", Sensitive: false},
+				"password": {Value: "secret", Sensitive: true},
+				"api_key":  {Value: "key123", Sensitive: true},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fields with non-conflicting aliases",
+			fields: map[string]Field{
+				"password": {Value: "secret", Aliases: []string{"pwd"}},
+				"username": {Value: "admin", Aliases: []string{"user"}},
+			},
+			wantErr: nil,
+		},
+
+		// Too many fields
+		{
+			name:    "too many fields",
+			fields:  makeManyFields(MaxFieldCount + 1),
+			wantErr: ErrTooManyFields,
+		},
+
+		// Alias conflicts with field name
+		{
+			name: "alias conflicts with field name",
+			fields: map[string]Field{
+				"password": {Value: "secret", Aliases: []string{"username"}},
+				"username": {Value: "admin"},
+			},
+			wantErr: ErrAliasConflict,
+		},
+
+		// Alias conflicts with another alias
+		{
+			name: "alias conflicts with another alias",
+			fields: map[string]Field{
+				"password": {Value: "secret", Aliases: []string{"cred"}},
+				"api_key":  {Value: "key", Aliases: []string{"cred"}},
+			},
+			wantErr: ErrAliasConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFields(tt.fields)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("ValidateFields() = %v, want nil", err)
+				}
+			} else {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ValidateFields() = %v, want %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBindings(t *testing.T) {
+	fields := map[string]Field{
+		"username": {Value: "admin", Sensitive: false},
+		"password": {Value: "secret", Sensitive: true, Aliases: []string{"pwd"}},
+		"api_key":  {Value: "key123", Sensitive: true},
+	}
+
+	tests := []struct {
+		name     string
+		bindings map[string]string
+		fields   map[string]Field
+		wantErr  error
+	}{
+		// Valid cases
+		{
+			name:     "empty bindings",
+			bindings: map[string]string{},
+			fields:   fields,
+			wantErr:  nil,
+		},
+		{
+			name: "valid bindings",
+			bindings: map[string]string{
+				"DB_USER": "username",
+				"DB_PASS": "password",
+			},
+			fields:  fields,
+			wantErr: nil,
+		},
+		{
+			name: "binding to alias",
+			bindings: map[string]string{
+				"PASSWORD": "pwd",
+			},
+			fields:  fields,
+			wantErr: nil,
+		},
+
+		// Invalid: field not found
+		{
+			name: "field not found",
+			bindings: map[string]string{
+				"DB_HOST": "hostname",
+			},
+			fields:  fields,
+			wantErr: ErrBindingFieldNotFound,
+		},
+
+		// Invalid: duplicate env var (case-insensitive)
+		{
+			name: "duplicate env var",
+			bindings: map[string]string{
+				"DB_PASS": "password",
+				"db_pass": "api_key",
+			},
+			fields:  fields,
+			wantErr: ErrBindingConflict,
+		},
+
+		// Too many bindings
+		{
+			name:     "too many bindings",
+			bindings: makeManyBindings(MaxBindingCount + 1),
+			fields:   makeManyFields(MaxBindingCount + 1),
+			wantErr:  ErrTooManyBindings,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBindings(tt.bindings, tt.fields)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("ValidateBindings() = %v, want nil", err)
+				}
+			} else {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ValidateBindings() = %v, want %v", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveFieldName(t *testing.T) {
+	fields := map[string]Field{
+		"password": {Value: "secret", Sensitive: true, Aliases: []string{"pwd", "pass"}},
+		"username": {Value: "admin", Sensitive: false},
+		"api_key":  {Value: "key123", Sensitive: true},
+	}
+
+	tests := []struct {
+		name          string
+		lookupName    string
+		wantFieldName string
+		wantValue     string
+		wantErr       error
+	}{
+		// Exact match
+		{
+			name:          "exact match",
+			lookupName:    "password",
+			wantFieldName: "password",
+			wantValue:     "secret",
+			wantErr:       nil,
+		},
+		// Alias match
+		{
+			name:          "alias match pwd",
+			lookupName:    "pwd",
+			wantFieldName: "password",
+			wantValue:     "secret",
+			wantErr:       nil,
+		},
+		{
+			name:          "alias match pass",
+			lookupName:    "pass",
+			wantFieldName: "password",
+			wantValue:     "secret",
+			wantErr:       nil,
+		},
+		// Case-insensitive alias match
+		{
+			name:          "case-insensitive alias",
+			lookupName:    "PWD",
+			wantFieldName: "password",
+			wantValue:     "secret",
+			wantErr:       nil,
+		},
+		// Case-insensitive field name match
+		{
+			name:          "case-insensitive field name",
+			lookupName:    "PASSWORD",
+			wantFieldName: "password",
+			wantValue:     "secret",
+			wantErr:       nil,
+		},
+		// Not found
+		{
+			name:       "not found",
+			lookupName: "nonexistent",
+			wantErr:    ErrFieldNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotField, err := ResolveFieldName(fields, tt.lookupName)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ResolveFieldName(%q) error = %v, want %v", tt.lookupName, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ResolveFieldName(%q) unexpected error: %v", tt.lookupName, err)
+				return
+			}
+			if gotName != tt.wantFieldName {
+				t.Errorf("ResolveFieldName(%q) name = %q, want %q", tt.lookupName, gotName, tt.wantFieldName)
+			}
+			if gotField.Value != tt.wantValue {
+				t.Errorf("ResolveFieldName(%q) value = %q, want %q", tt.lookupName, gotField.Value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestNewDefaultField(t *testing.T) {
+	value := "test-secret-value"
+	field := NewDefaultField(value)
+
+	if field.Value != value {
+		t.Errorf("NewDefaultField().Value = %q, want %q", field.Value, value)
+	}
+	if !field.Sensitive {
+		t.Error("NewDefaultField().Sensitive = false, want true")
+	}
+	if len(field.Aliases) != 0 {
+		t.Errorf("NewDefaultField().Aliases = %v, want empty", field.Aliases)
+	}
+	if field.Kind != "" {
+		t.Errorf("NewDefaultField().Kind = %q, want empty", field.Kind)
+	}
+	if field.Hint != "" {
+		t.Errorf("NewDefaultField().Hint = %q, want empty", field.Hint)
+	}
+}
+
+func TestConvertSingleValueToFields(t *testing.T) {
+	value := []byte("my-secret-value")
+	fields := ConvertSingleValueToFields(value)
+
+	if len(fields) != 1 {
+		t.Fatalf("ConvertSingleValueToFields() returned %d fields, want 1", len(fields))
+	}
+
+	field, ok := fields[DefaultFieldName]
+	if !ok {
+		t.Fatalf("ConvertSingleValueToFields() missing %q field", DefaultFieldName)
+	}
+
+	if field.Value != string(value) {
+		t.Errorf("ConvertSingleValueToFields() value = %q, want %q", field.Value, string(value))
+	}
+	if !field.Sensitive {
+		t.Error("ConvertSingleValueToFields() sensitive = false, want true")
+	}
+}
+
+func TestGetDefaultFieldValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]Field
+		want   string
+	}{
+		{
+			name: "has default field",
+			fields: map[string]Field{
+				DefaultFieldName: {Value: "secret"},
+			},
+			want: "secret",
+		},
+		{
+			name: "no default field",
+			fields: map[string]Field{
+				"password": {Value: "secret"},
+			},
+			want: "",
+		},
+		{
+			name:   "empty fields",
+			fields: map[string]Field{},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetDefaultFieldValue(tt.fields)
+			if got != tt.want {
+				t.Errorf("GetDefaultFieldValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSingleFieldSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]Field
+		want   bool
+	}{
+		{
+			name: "single value field",
+			fields: map[string]Field{
+				DefaultFieldName: {Value: "secret"},
+			},
+			want: true,
+		},
+		{
+			name: "multi-field",
+			fields: map[string]Field{
+				"username": {Value: "admin"},
+				"password": {Value: "secret"},
+			},
+			want: false,
+		},
+		{
+			name: "single non-default field",
+			fields: map[string]Field{
+				"password": {Value: "secret"},
+			},
+			want: false,
+		},
+		{
+			name:   "empty fields",
+			fields: map[string]Field{},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSingleFieldSecret(tt.fields)
+			if got != tt.want {
+				t.Errorf("IsSingleFieldSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Helper functions
+
+func makeManyFields(count int) map[string]Field {
+	fields := make(map[string]Field, count)
+	for i := 0; i < count; i++ {
+		name := "field" + string(rune('a'+i%26)) + string(rune('0'+i/26%10))
+		fields[name] = Field{Value: "value"}
+	}
+	return fields
+}
+
+func makeManyBindings(count int) map[string]string {
+	bindings := make(map[string]string, count)
+	for i := 0; i < count; i++ {
+		envVar := "ENV_VAR_" + string(rune('A'+i%26)) + string(rune('0'+i/26%10))
+		fieldName := "field" + string(rune('a'+i%26)) + string(rune('0'+i/26%10))
+		bindings[envVar] = fieldName
+	}
+	return bindings
+}

--- a/pkg/vault/migration.go
+++ b/pkg/vault/migration.go
@@ -1,0 +1,181 @@
+// Package vault provides secure secret storage with AES-256-GCM encryption.
+package vault
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Schema version constants
+const (
+	// SchemaVersion1 is the original single-value schema
+	SchemaVersion1 = 1
+	// SchemaVersion2 adds multi-field support (Phase 2.5)
+	SchemaVersion2 = 2
+	// CurrentSchemaVersion is the current schema version
+	CurrentSchemaVersion = SchemaVersion2
+)
+
+// getSchemaVersion returns the current schema version from the database.
+// Returns 1 if no version is stored (legacy database).
+func getSchemaVersion(db *sql.DB) (int, error) {
+	// Check if schema_version table exists
+	var tableName string
+	err := db.QueryRow(`
+		SELECT name FROM sqlite_master
+		WHERE type='table' AND name='schema_version'
+	`).Scan(&tableName)
+
+	if err == sql.ErrNoRows {
+		// No schema_version table = version 1 (legacy)
+		return SchemaVersion1, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("vault: failed to check schema_version table: %w", err)
+	}
+
+	// Get the version
+	var version int
+	err = db.QueryRow("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").Scan(&version)
+	if err == sql.ErrNoRows {
+		return SchemaVersion1, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("vault: failed to get schema version: %w", err)
+	}
+
+	return version, nil
+}
+
+// setSchemaVersion sets the schema version in the database.
+func setSchemaVersion(db *sql.DB, version int) error {
+	// Create schema_version table if it doesn't exist
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_version (
+			version INTEGER PRIMARY KEY,
+			migrated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("vault: failed to create schema_version table: %w", err)
+	}
+
+	// Insert the version
+	_, err = db.Exec("INSERT OR REPLACE INTO schema_version (version) VALUES (?)", version)
+	if err != nil {
+		return fmt.Errorf("vault: failed to set schema version: %w", err)
+	}
+
+	return nil
+}
+
+// migrateSchema migrates the database schema to the current version.
+func migrateSchema(db *sql.DB) error {
+	version, err := getSchemaVersion(db)
+	if err != nil {
+		return err
+	}
+
+	// Apply migrations in order
+	if version < SchemaVersion2 {
+		if err := migrateToV2(db); err != nil {
+			return fmt.Errorf("vault: migration to v2 failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// migrateToV2 adds multi-field support columns.
+// This migration:
+// 1. Adds encrypted_fields column (BLOB, nullable for backward compat)
+// 2. Adds encrypted_bindings column (BLOB, nullable)
+// 3. Adds schema column (TEXT, nullable, for Phase 3)
+// 4. Updates schema version
+//
+// Note: Existing data is NOT migrated during schema migration.
+// Conversion happens on-the-fly during read operations:
+// - If encrypted_fields is NULL and encrypted_value is not, auto-convert to Fields["value"]
+// - This lazy migration approach minimizes downtime and risk.
+func migrateToV2(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Check if columns already exist (idempotent migration)
+	columns, err := getTableColumns(tx, "secrets")
+	if err != nil {
+		return fmt.Errorf("failed to get table columns: %w", err)
+	}
+
+	// Add encrypted_fields column if it doesn't exist
+	if !columns["encrypted_fields"] {
+		_, err = tx.Exec("ALTER TABLE secrets ADD COLUMN encrypted_fields BLOB")
+		if err != nil {
+			return fmt.Errorf("failed to add encrypted_fields column: %w", err)
+		}
+	}
+
+	// Add encrypted_bindings column if it doesn't exist
+	if !columns["encrypted_bindings"] {
+		_, err = tx.Exec("ALTER TABLE secrets ADD COLUMN encrypted_bindings BLOB")
+		if err != nil {
+			return fmt.Errorf("failed to add encrypted_bindings column: %w", err)
+		}
+	}
+
+	// Add schema column if it doesn't exist
+	if !columns["schema"] {
+		_, err = tx.Exec("ALTER TABLE secrets ADD COLUMN schema TEXT")
+		if err != nil {
+			return fmt.Errorf("failed to add schema column: %w", err)
+		}
+	}
+
+	// Update schema version
+	_, err = tx.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_version (
+			version INTEGER PRIMARY KEY,
+			migrated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create schema_version table: %w", err)
+	}
+
+	_, err = tx.Exec("INSERT OR REPLACE INTO schema_version (version) VALUES (?)", SchemaVersion2)
+	if err != nil {
+		return fmt.Errorf("failed to set schema version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit migration: %w", err)
+	}
+
+	return nil
+}
+
+// getTableColumns returns a map of column names for a table.
+func getTableColumns(tx *sql.Tx, tableName string) (map[string]bool, error) {
+	rows, err := tx.Query(fmt.Sprintf("PRAGMA table_info(%s)", tableName))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dfltValue sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return nil, err
+		}
+		columns[name] = true
+	}
+
+	return columns, rows.Err()
+}

--- a/pkg/vault/migration_test.go
+++ b/pkg/vault/migration_test.go
@@ -1,0 +1,278 @@
+// Package vault provides secure secret storage with AES-256-GCM encryption.
+package vault
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestGetSchemaVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Create a bare database without schema_version table
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Test: No schema_version table should return version 1
+	version, err := getSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("getSchemaVersion failed: %v", err)
+	}
+	if version != SchemaVersion1 {
+		t.Errorf("expected version %d, got %d", SchemaVersion1, version)
+	}
+}
+
+func TestSetSchemaVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Set version 2
+	if err := setSchemaVersion(db, SchemaVersion2); err != nil {
+		t.Fatalf("setSchemaVersion failed: %v", err)
+	}
+
+	// Verify version was set
+	version, err := getSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("getSchemaVersion failed: %v", err)
+	}
+	if version != SchemaVersion2 {
+		t.Errorf("expected version %d, got %d", SchemaVersion2, version)
+	}
+
+	// Update version
+	if err := setSchemaVersion(db, SchemaVersion2+1); err != nil {
+		t.Fatalf("setSchemaVersion update failed: %v", err)
+	}
+
+	version, err = getSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("getSchemaVersion after update failed: %v", err)
+	}
+	if version != SchemaVersion2+1 {
+		t.Errorf("expected version %d, got %d", SchemaVersion2+1, version)
+	}
+}
+
+func TestMigrateToV2(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create v1 schema (without multi-field columns)
+	_, err = db.Exec(`
+		CREATE TABLE secrets (
+			key_hash TEXT PRIMARY KEY,
+			encrypted_value BLOB NOT NULL,
+			encrypted_key BLOB NOT NULL,
+			encrypted_metadata BLOB,
+			encrypted_tags BLOB,
+			expires_at TIMESTAMP,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create v1 schema: %v", err)
+	}
+
+	// Add some test data
+	_, err = db.Exec(`
+		INSERT INTO secrets (key_hash, encrypted_value, encrypted_key)
+		VALUES ('hash1', X'0102030405', X'0102030405')
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert test data: %v", err)
+	}
+
+	// Run migration
+	if err := migrateToV2(db); err != nil {
+		t.Fatalf("migrateToV2 failed: %v", err)
+	}
+
+	// Verify new columns exist
+	columns, err := getTableColumnsFromDB(db, "secrets")
+	if err != nil {
+		t.Fatalf("failed to get columns: %v", err)
+	}
+
+	expectedColumns := []string{"encrypted_fields", "encrypted_bindings", "schema"}
+	for _, col := range expectedColumns {
+		if !columns[col] {
+			t.Errorf("missing column after migration: %s", col)
+		}
+	}
+
+	// Verify schema version
+	version, err := getSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("getSchemaVersion failed: %v", err)
+	}
+	if version != SchemaVersion2 {
+		t.Errorf("expected schema version %d, got %d", SchemaVersion2, version)
+	}
+
+	// Run migration again (should be idempotent)
+	if err := migrateToV2(db); err != nil {
+		t.Fatalf("migrateToV2 (idempotent) failed: %v", err)
+	}
+}
+
+func TestMigrateSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create v1 schema
+	_, err = db.Exec(`
+		CREATE TABLE secrets (
+			key_hash TEXT PRIMARY KEY,
+			encrypted_value BLOB NOT NULL,
+			encrypted_key BLOB NOT NULL,
+			encrypted_metadata BLOB,
+			encrypted_tags BLOB,
+			expires_at TIMESTAMP,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create v1 schema: %v", err)
+	}
+
+	// Run full migration
+	if err := migrateSchema(db); err != nil {
+		t.Fatalf("migrateSchema failed: %v", err)
+	}
+
+	// Verify we're at current version
+	version, err := getSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("getSchemaVersion failed: %v", err)
+	}
+	if version != CurrentSchemaVersion {
+		t.Errorf("expected current schema version %d, got %d", CurrentSchemaVersion, version)
+	}
+}
+
+func TestGetTableColumns(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Create test table
+	_, err = db.Exec(`
+		CREATE TABLE test_table (
+			id INTEGER PRIMARY KEY,
+			name TEXT,
+			value BLOB
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create test table: %v", err)
+	}
+
+	// Get columns using transaction
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("failed to begin transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	columns, err := getTableColumns(tx, "test_table")
+	if err != nil {
+		t.Fatalf("getTableColumns failed: %v", err)
+	}
+
+	expected := []string{"id", "name", "value"}
+	for _, col := range expected {
+		if !columns[col] {
+			t.Errorf("missing column: %s", col)
+		}
+	}
+	if len(columns) != len(expected) {
+		t.Errorf("expected %d columns, got %d", len(expected), len(columns))
+	}
+}
+
+// Helper function for testing - uses db.Query directly instead of transaction
+func getTableColumnsFromDB(db *sql.DB, tableName string) (map[string]bool, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	return getTableColumns(tx, tableName)
+}
+
+func TestVaultSchemaMigrationOnUnlock(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Set secure permissions for the vault directory
+	if err := os.Chmod(tmpDir, 0700); err != nil {
+		t.Fatalf("failed to set directory permissions: %v", err)
+	}
+
+	v := New(tmpDir)
+	password := "testpassword123"
+
+	// Initialize vault (creates v2 schema directly)
+	if err := v.Init(password); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	// Unlock - should run migration check
+	if err := v.Unlock(password); err != nil {
+		t.Fatalf("Unlock failed: %v", err)
+	}
+	defer v.Lock()
+
+	// Verify vault is functional
+	entry := &SecretEntry{
+		Fields: map[string]Field{
+			"test_field": {Value: "test_value", Sensitive: true},
+		},
+	}
+	if err := v.SetSecret("test/migration", entry); err != nil {
+		t.Fatalf("SetSecret failed: %v", err)
+	}
+
+	retrieved, err := v.GetSecret("test/migration")
+	if err != nil {
+		t.Fatalf("GetSecret failed: %v", err)
+	}
+
+	if retrieved.Fields["test_field"].Value != "test_value" {
+		t.Errorf("value mismatch after migration check")
+	}
+}


### PR DESCRIPTION
## Summary

Implement multi-field secrets support per ADR-002:

- Add `Field` struct with Value, Sensitive, Aliases, Kind, Hint
- Add `Fields` map and `Bindings` map to SecretEntry
- Add field name validation (snake_case, 1-64 chars)
- Add SQLite schema migration (v1 → v2) with automatic upgrade
- Add automatic legacy data conversion (Value → Fields["value"])
- Update SetSecret/GetSecret for multi-field support
- Maintain full backward compatibility with existing vaults

### Key Features

**Multi-field support:**
```go
entry := &SecretEntry{
    Fields: map[string]Field{
        "username": {Value: "admin", Sensitive: false},
        "password": {Value: "secret", Sensitive: true, Aliases: []string{"pwd"}},
    },
    Bindings: map[string]string{
        "DB_USER": "username",
        "DB_PASS": "password",
    },
}
```

**Backward compatibility:**
- Legacy `Value` field still works
- Auto-converts to `Fields["value"]` on read
- Existing vaults auto-migrate on unlock

## Test plan

- [x] All existing vault tests pass
- [x] New field validation tests (100% coverage)
- [x] New migration tests (93% coverage)
- [x] Multi-field SetSecret/GetSecret integration tests
- [x] Legacy data conversion tests
- [x] Alias resolution tests
- [x] golangci-lint passes

Test coverage: 78.6% (target: 80%)

Closes #104