### PR TITLE
docs: add Phase 2.5c MCP tools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ SECRETCTL_PASSWORD=your-password secretctl mcp-server
 - `secret_exists` — Check if a secret exists with metadata
 - `secret_get_masked` — Get masked value (e.g., `****WXYZ`)
 - `secret_run` — Execute commands with secrets as environment variables
+- `secret_list_fields` — List field names for multi-field secrets (no values)
+- `secret_get_field` — Get non-sensitive field values only
+- `secret_run_with_bindings` — Execute with predefined environment bindings
 
 **Configure in Claude Code** (`~/.claude.json`):
 ```json


### PR DESCRIPTION
## Summary

Add documentation for Phase 2.5c MCP tools to README and website.

### Changes

- **README.md**: Added 3 new MCP tools (secret_list_fields, secret_get_field, secret_run_with_bindings)
- **website/docs/guides/mcp/available-tools.md**: 
  - Updated tool count from 4 to 7
  - Added full documentation for new tools
  - Fixed response schema inconsistencies
- **website/docs/reference/mcp-tools.md**:
  - Added API reference for new tools
  - Updated Option D+ architecture table

### Fixes

- Fixed `secret_exists` response shape (removed nested `metadata` wrapper)
- Fixed `secret_get_masked` field name (`length` → `value_length`)

Related to PR #110 (Phase 2.5c implementation)