### PR TITLE
feat(mcp): add field_count to secret_list output

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -37,13 +37,14 @@ type SecretListOutput struct {
 
 // SecretInfo represents metadata for a secret (no value).
 type SecretInfo struct {
-	Key       string   `json:"key"`
-	Tags      []string `json:"tags,omitempty"`
-	ExpiresAt string   `json:"expires_at,omitempty"`
-	HasNotes  bool     `json:"has_notes"`
-	HasURL    bool     `json:"has_url"`
-	CreatedAt string   `json:"created_at"`
-	UpdatedAt string   `json:"updated_at"`
+	Key        string   `json:"key"`
+	FieldCount int      `json:"field_count"`
+	Tags       []string `json:"tags,omitempty"`
+	ExpiresAt  string   `json:"expires_at,omitempty"`
+	HasNotes   bool     `json:"has_notes"`
+	HasURL     bool     `json:"has_url"`
+	CreatedAt  string   `json:"created_at"`
+	UpdatedAt  string   `json:"updated_at"`
 }
 
 // SecretExistsInput represents input for secret_exists tool.
@@ -178,12 +179,13 @@ func (s *Server) handleSecretList(_ context.Context, _ *mcp.CallToolRequest, inp
 
 	for _, entry := range entries {
 		info := SecretInfo{
-			Key:       entry.Key,
-			Tags:      entry.Tags,
-			HasNotes:  entry.Metadata != nil && entry.Metadata.Notes != "",
-			HasURL:    entry.Metadata != nil && entry.Metadata.URL != "",
-			CreatedAt: entry.CreatedAt.Format(time.RFC3339),
-			UpdatedAt: entry.UpdatedAt.Format(time.RFC3339),
+			Key:        entry.Key,
+			FieldCount: entry.FieldCount,
+			Tags:       entry.Tags,
+			HasNotes:   entry.Metadata != nil && entry.Metadata.Notes != "",
+			HasURL:     entry.Metadata != nil && entry.Metadata.URL != "",
+			CreatedAt:  entry.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:  entry.UpdatedAt.Format(time.RFC3339),
 		}
 		if entry.ExpiresAt != nil {
 			info.ExpiresAt = entry.ExpiresAt.Format(time.RFC3339)

--- a/website/docs/reference/mcp-tools.md
+++ b/website/docs/reference/mcp-tools.md
@@ -51,6 +51,7 @@ List all secret keys with metadata. Returns key names, tags, expiration, and fla
   "secrets": [
     {
       "key": "string",
+      "field_count": "number",
       "tags": ["string"],
       "expires_at": "string (RFC 3339, optional)",
       "has_notes": "boolean",
@@ -61,6 +62,17 @@ List all secret keys with metadata. Returns key names, tags, expiration, and fla
   ]
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Secret key name |
+| `field_count` | number | Number of fields (1 for legacy single-value secrets) |
+| `tags` | array | Tags associated with the secret |
+| `expires_at` | string | Expiration date in RFC 3339 format (optional) |
+| `has_notes` | boolean | Whether the secret has notes |
+| `has_url` | boolean | Whether the secret has a URL |
+| `created_at` | string | Creation timestamp in RFC 3339 format |
+| `updated_at` | string | Last update timestamp in RFC 3339 format |
 
 ### Examples
 
@@ -75,6 +87,7 @@ List all secret keys with metadata. Returns key names, tags, expiration, and fla
   "secrets": [
     {
       "key": "AWS_ACCESS_KEY",
+      "field_count": 1,
       "tags": ["aws", "prod"],
       "has_notes": false,
       "has_url": true,
@@ -82,7 +95,8 @@ List all secret keys with metadata. Returns key names, tags, expiration, and fla
       "updated_at": "2025-01-15T10:30:00Z"
     },
     {
-      "key": "DB_PASSWORD",
+      "key": "db/prod",
+      "field_count": 5,
       "tags": ["db", "prod"],
       "expires_at": "2025-06-15T00:00:00Z",
       "has_notes": true,


### PR DESCRIPTION
## Summary

Extend `secret_list` MCP tool to include `field_count` for each secret:
- Legacy single-value secrets show `field_count: 1`
- Multi-field secrets show actual field count (e.g., 5 for database template)

## Implementation

- Add SchemaVersion3 migration with `field_count` column (INTEGER DEFAULT 1)
- Store `field_count` in plaintext (not sensitive, Option D+ compliant)
- Update `SetSecret` to calculate and store `field_count`
- Update `ListSecretsWithMetadata` to query and return `field_count`
- Add `FieldCount` to `SecretInfo` struct in MCP tools
- Update MCP documentation with new field

## Test Plan

- [x] Add `TestMigrateToV3` for schema migration
- [x] Add `TestFieldCountInListSecretsWithMetadata` for field count functionality
- [x] All existing tests pass
- [x] Linting passes

Closes #120