### PR TITLE
release: v0.7.0 - Phase 2.5 Multi-Field Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-12-30
+
+### Added
+- **Multi-Field Secrets (Phase 2.5)** - Support for storing multiple key-value pairs in a single secret
+  - New `Fields` map with name, value, and sensitivity settings per field
+  - Database schema migration to v3 with backward compatibility
+  - Well-known field names: `username`, `password`, `url`, `notes`, `host`, `port`, `database`, `api_key`
+
+- **CLI Multi-Field Support**
+  - `set --field name=value` for adding individual fields
+  - `set --template login|database|api|ssh` for pre-defined templates
+  - `set --binding field=ENV_VAR` for environment variable mappings
+  - `get --field name` to retrieve a specific field
+  - `get --fields` to list all field names
+
+- **MCP Multi-Field Tools**
+  - `secret_list` now includes `field_count` for each secret
+  - `secret_list_fields` to list all field names for a secret
+  - `secret_get_field` to retrieve a specific non-sensitive field value
+  - `secret_get_masked` extended with `fields` map showing all fields with masking
+  - `secret_run_with_bindings` for flexible environment variable injection
+
+- **Desktop App Multi-Field UI**
+  - Multi-field editing interface with add/remove field buttons
+  - Template selection dropdown (Login, Database, API, SSH)
+  - Sensitive field toggle per field
+  - Field-level visibility controls
+
+- **Documentation**
+  - Well-known field names reference (`website/docs/reference/field-names.md`)
+  - Updated MCP tools documentation with multi-field examples
+
+### Security
+- Sensitive field values are always masked in MCP responses
+- Non-sensitive fields can be read via `secret_get_field` (e.g., username, host)
+- `field_count` stored in plaintext for efficient querying (Option D+ compliant)
+
 ## [0.6.0] - 2025-12-24
 
 ### Added


### PR DESCRIPTION
## Summary

Release v0.7.0 containing all Phase 2.5 multi-field secrets features.

### Included Features

**Phase 2.5a: Data Model Extension**
- Secret struct with Fields map
- SQLite schema migration (v1→v2→v3)
- Field validation and sensitivity settings

**Phase 2.5b: CLI Extension**
- `set --field`, `--template`, `--binding` options
- `get --field`, `--fields` options
- Templates: login, database, api, ssh

**Phase 2.5c: MCP Extension**
- `secret_list` with `field_count`
- `secret_list_fields` tool
- `secret_get_field` tool (non-sensitive only)
- `secret_get_masked` with `fields` map
- `secret_run_with_bindings` tool

**Phase 2.5d: Desktop App**
- Multi-field editing UI
- Template selection UI
- Sensitive field toggle

**Additional Enhancements**
- Well-known field names documentation (#119)
- Field count in secret_list (#120)
- Extended secret_get_masked for multi-field (#121)

## Test plan

- [x] All CI checks pass
- [x] CHANGELOG.md updated

After merge, create and push tag `v0.7.0`.

Closes #122