### PR TITLE
fix(release): match archive id with build id for brews/scoops

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,9 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - id: cli-archives
+  - id: secretctl
+    builds:
+      - secretctl
     formats:
       - tar.gz
       - zip


### PR DESCRIPTION
## Summary
- Fix GoReleaser archive ID mismatch causing release failure
- Changed archive id from 'cli-archives' to 'secretctl' to match brews/scoops ids filter

## Issue
v0.8.0 release failed with:
```
no linux/macos archives found matching goos=[darwin linux] goarch=[amd64 arm64 arm] goamd64=v1 goarm=6 ids=[secretctl]
```

## Root Cause
`brews.ids` and `scoops.ids` filter by archive ID, not build ID. The archive had `id: cli-archives` but brews/scoops were looking for `ids: [secretctl]`.

## Fix
Changed archive configuration to use `id: secretctl` with explicit `builds: [secretctl]`.