### PR TITLE
fix(release): use single archive format per platform

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,11 +33,8 @@ builds:
 
 archives:
   - id: secretctl
-    builds:
-      - secretctl
     formats:
       - tar.gz
-      - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows


### PR DESCRIPTION
## Summary
- Fix Homebrew error: only one archive per OS/Arch is supported
- Changed to use tar.gz for darwin/linux, zip for windows only

## Error Fixed
```
one tap can handle only one archive of an OS/Arch combination
```

## Changes
- Removed `builds:` (deprecated in GoReleaser v2)
- Removed dual format (tar.gz + zip) for all platforms
- Now: tar.gz for darwin/linux, zip for windows (via format_overrides)