### PR TITLE
docs: rename Option D+ to AI-Safe Access for industry alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
-      # Option D+ Compliance Check
-      - name: Option D+ Check - No plaintext secret returns
+      # AI-Safe Access Compliance Check
+      - name: AI-Safe Access Check - No plaintext secret returns
         run: |
           set -euo pipefail
           if grep -rn "secret_get\s*=" internal/mcp/ 2>/dev/null | grep -v "masked\|Masked"; then
@@ -60,7 +60,7 @@ jobs:
           fi
           echo "OK: No plaintext secret getters"
 
-      - name: Option D+ Check - Output sanitization
+      - name: AI-Safe Access Check - Output sanitization
         run: |
           set -euo pipefail
           if ! grep -rq "Sanitize\|sanitize\|REDACTED" internal/mcp/ 2>/dev/null; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Sensitive field values are always masked in MCP responses
 - Non-sensitive fields can be read via `secret_get_field` (e.g., username, host)
-- `field_count` stored in plaintext for efficient querying (Option D+ compliant)
+- `field_count` stored in plaintext for efficient querying (AI-Safe Access compliant)
 
 ## [0.6.0] - 2025-12-24
 
@@ -130,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Policy-based command allowlisting via `~/.secretctl/mcp-policy.yaml`
 
 ### Security
-- **Option D+ design**: AI agents never receive plaintext secrets
+- **AI-Safe Access design**: AI agents never receive plaintext secrets
 - Default denied commands (env, printenv, set, export) always blocked
 - Output sanitization in secret_run prevents secret leakage
 - TOCTOU-safe policy file loading with symlink rejection

--- a/README.md
+++ b/README.md
@@ -259,6 +259,37 @@ secretctl audit export --format=csv -o audit.csv
 secretctl audit prune --older-than=12m --dry-run
 ```
 
+### AI-Safe Access
+
+secretctl implements **AI-Safe Access** — a security principle where AI agents never receive plaintext secrets.
+
+Unlike traditional secret managers that might expose credentials directly to AI, secretctl uses a fundamentally different approach:
+
+```mermaid
+flowchart LR
+    subgraph "Traditional Approach ❌"
+        AI1[AI Agent] -->|"get secret"| SM1[Secret Manager]
+        SM1 -->|"plaintext: sk-xxx..."| AI1
+    end
+
+    subgraph "AI-Safe Access ✅"
+        AI2[AI Agent] -->|"run command"| SM2[secretctl]
+        SM2 -->|"inject env vars"| CMD[Command]
+        CMD -->|"sanitized output"| SM2
+        SM2 -->|"[REDACTED]"| AI2
+    end
+```
+
+**How it works:**
+
+| Tool | What AI Sees | What Happens |
+|------|--------------|--------------|
+| `secret_list` | Key names, metadata | No values exposed |
+| `secret_get_masked` | `****WXYZ` | Last 4 chars only |
+| `secret_run` | `[REDACTED:KEY]` | Secrets injected as env vars, output sanitized |
+
+This follows the **"Access Without Exposure"** philosophy used by industry leaders like 1Password and HashiCorp Vault.
+
 ### AI Integration (MCP Server)
 
 secretctl includes an MCP server for secure integration with AI coding assistants like Claude Code:

--- a/claudedocs/postgresql-mcp-competitive-analysis.md
+++ b/claudedocs/postgresql-mcp-competitive-analysis.md
@@ -2,9 +2,9 @@
 
 ## Executive Summary
 
-This analysis examines how competing MCP servers handle database credentials, with focus on PostgreSQL implementations. The goal is to identify best practices for integrating secretctl with database MCP servers while maintaining Option D+ security principles.
+This analysis examines how competing MCP servers handle database credentials, with focus on PostgreSQL implementations. The goal is to identify best practices for integrating secretctl with database MCP servers while maintaining AI-Safe Access security principles.
 
-**Key Finding**: Most PostgreSQL MCP servers have significant security weaknesses. secretctl's Option D+ design can provide superior security through credential injection without AI exposure.
+**Key Finding**: Most PostgreSQL MCP servers have significant security weaknesses. secretctl's AI-Safe Access design can provide superior security through credential injection without AI exposure.
 
 ---
 
@@ -230,7 +230,7 @@ secretctl run -k "POSTGRES_*" -- npx @anthropic/postgres-mcp
 │  (credentials)  │──inject──▶   │  (operations)   │
 └─────────────────┘              └─────────────────┘
        │
-  Option D+
+  AI-Safe Access
   (AI never sees
    plaintext)
 ```
@@ -290,7 +290,7 @@ Potential features:
 
 ## Conclusion
 
-secretctl's Option D+ design aligns with industry best practices (1Password, HashiCorp Vault) for AI-era credential management. The key insight from competitive analysis:
+secretctl's AI-Safe Access design aligns with industry best practices (1Password, HashiCorp Vault) for AI-era credential management. The key insight from competitive analysis:
 
 > **Credentials should be injected on behalf of the agent, without handing them over.**
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,5 +1,5 @@
 // Package mcp implements the MCP (Model Context Protocol) server for secretctl.
-// This implements the Option D+ design where AI agents never receive plaintext secrets.
+// This implements the "AI-Safe Access" design where AI agents never receive plaintext secrets.
 package mcp
 
 import (
@@ -139,7 +139,7 @@ func (s *Server) registerTools() {
 	// secret_get_field - Get a non-sensitive field value
 	mcp.AddTool(s.server, &mcp.Tool{
 		Name:        "secret_get_field",
-		Description: "Get a specific field value from a multi-field secret. Only non-sensitive fields can be retrieved (Option D+ policy). Sensitive fields will be rejected.",
+		Description: "Get a specific field value from a multi-field secret. Only non-sensitive fields can be retrieved (AI-Safe Access policy). Sensitive fields will be rejected.",
 	}, s.handleSecretGetField)
 
 	// secret_run_with_bindings - Execute command with binding-based environment variables

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1275,7 +1275,7 @@ func TestHandleSecretGetField_SensitiveRejected(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for sensitive field")
 	}
-	if err.Error() != "field 'password' is marked as sensitive and cannot be retrieved via MCP (Option D+ policy)" {
+	if err.Error() != "field 'password' is marked as sensitive and cannot be retrieved via MCP (AI-Safe Access policy)" {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -173,7 +173,7 @@ func (s *Server) handleSecretList(_ context.Context, _ *mcp.CallToolRequest, inp
 		}
 	default:
 		// List all secrets with metadata but WITHOUT decrypting values
-		// This follows Option D+ principle: minimize plaintext exposure
+		// This follows AI-Safe Access principle: minimize plaintext exposure
 		entries, err = s.vault.ListSecretsWithMetadata()
 		if err != nil {
 			_ = s.vault.Audit().LogError(audit.OpSecretList, audit.SourceMCP, "", "LIST_FAILED", err.Error())
@@ -489,7 +489,7 @@ func (s *Server) handleSecretListFields(_ context.Context, _ *mcp.CallToolReques
 }
 
 // handleSecretGetField handles the secret_get_field tool call.
-// Per Option D+: Only non-sensitive fields can be retrieved via MCP.
+// Per AI-Safe Access: Only non-sensitive fields can be retrieved via MCP.
 func (s *Server) handleSecretGetField(_ context.Context, _ *mcp.CallToolRequest, input SecretGetFieldInput) (*mcp.CallToolResult, SecretGetFieldOutput, error) {
 	if input.Key == "" {
 		_ = s.vault.Audit().LogError(audit.OpSecretGetField, audit.SourceMCP, "", "INVALID_INPUT", "key is required")
@@ -513,10 +513,10 @@ func (s *Server) handleSecretGetField(_ context.Context, _ *mcp.CallToolRequest,
 		return nil, SecretGetFieldOutput{}, fmt.Errorf("field '%s' not found in secret '%s'", input.Field, input.Key)
 	}
 
-	// Option D+ enforcement: Reject sensitive fields
+	// AI-Safe Access enforcement: Reject sensitive fields
 	if field.Sensitive {
 		_ = s.vault.Audit().LogDenied(audit.OpSecretGetFieldDenied, audit.SourceMCP, input.Key, fmt.Sprintf("sensitive field: %s", canonicalName))
-		return nil, SecretGetFieldOutput{}, fmt.Errorf("field '%s' is marked as sensitive and cannot be retrieved via MCP (Option D+ policy)", canonicalName)
+		return nil, SecretGetFieldOutput{}, fmt.Errorf("field '%s' is marked as sensitive and cannot be retrieved via MCP (AI-Safe Access policy)", canonicalName)
 	}
 
 	// Log successful get field operation

--- a/pkg/vault/migration.go
+++ b/pkg/vault/migration.go
@@ -205,7 +205,7 @@ func getTableColumns(tx *sql.Tx, tableName string) (map[string]bool, error) {
 // 2. Updates schema version
 //
 // The field_count is stored in plaintext (not encrypted) as it's not sensitive
-// and allows efficient querying without decryption (Option D+ compliant).
+// and allows efficient querying without decryption (AI-Safe Access compliant).
 //
 // Note: Multi-field secrets created on v2 schema will have incorrect field_count=1
 // until re-saved. This is acceptable because:

--- a/scripts/smoke-test-cli.sh
+++ b/scripts/smoke-test-cli.sh
@@ -72,9 +72,9 @@ if ! echo "$LIST" | grep -q "test/smoke-key"; then
 fi
 echo "   PASS"
 
-# Test 6: Run command (Option D+ - env injection)
+# Test 6: Run command (AI-Safe Access - env injection)
 echo ""
-echo "6. Testing run command (Option D+)..."
+echo "6. Testing run command (AI-Safe Access)..."
 $BINARY set test/env-key "env-secret-456"
 if [[ "$(uname)" == "MINGW"* ]] || [[ "$(uname)" == "MSYS"* ]]; then
     # Windows

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -20,7 +20,7 @@ This document describes the high-level architecture of secretctl, including comp
 │  │  (Cobra)    │   │   (Wails)   │   │   (stdio)   │                       │
 │  └──────┬──────┘   └──────┬──────┘   └──────┬──────┘                       │
 │         │                 │                 │                               │
-│         │    Full Trust   │    Full Trust   │   Restricted (Option D+)     │
+│         │    Full Trust   │    Full Trust   │   Restricted (AI-Safe Access)│
 │         │                 │                 │                               │
 │         └────────────────┼────────────────┘                               │
 │                          │                                                  │
@@ -60,7 +60,7 @@ This document describes the high-level architecture of secretctl, including comp
 |-----------|----------------|---------|
 | **CLI** | Command-line interface, user interaction | `cmd/secretctl` |
 | **Desktop** | Native GUI application | `desktop/` |
-| **MCP Server** | AI agent integration, Option D+ enforcement | `internal/mcp` |
+| **MCP Server** | AI agent integration, AI-Safe Access enforcement | `internal/mcp` |
 | **Vault Manager** | Lifecycle (init, lock, unlock), session management | `pkg/vault` |
 | **Secrets Store** | CRUD operations, metadata handling | `pkg/vault` |
 | **Audit Log** | HMAC-chained event logging, integrity verification | `pkg/vault` |
@@ -95,7 +95,7 @@ User                    CLI                     Vault                   Crypto
   │       OK             │                        │                       │
 ```
 
-### MCP secret_run Operation (Option D+)
+### MCP secret_run Operation (AI-Safe Access)
 
 ```
 AI Agent            MCP Server              Vault              Subprocess
@@ -147,7 +147,7 @@ AI Agent            MCP Server              Vault              Subprocess
 │  │                                                                         │ │
 │  └───────────────────────────────────────────────────────────────────────┘ │
 │                                    │                                        │
-│                                    │ Option D+ Boundary                     │
+│                                    │ AI-Safe Access Boundary                │
 │                                    ▼                                        │
 │  ┌───────────────────────────────────────────────────────────────────────┐ │
 │  │                                                                         │ │
@@ -192,7 +192,7 @@ AI Agent            MCP Server              Vault              Subprocess
 | **S**poofing | No | Local-only, no network auth |
 | **T**ampering | Yes | HMAC chain audit logs, encrypted storage |
 | **R**epudiation | Yes | Audit logging with timestamps |
-| **I**nformation Disclosure | Yes | Option D+, output sanitization |
+| **I**nformation Disclosure | Yes | AI-Safe Access, output sanitization |
 | **D**enial of Service | Limited | Timeout on commands (300s) |
 | **E**levation of Privilege | Yes | Trust boundary enforcement |
 

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -27,7 +27,7 @@ secretctl uses industry-standard encryption:
 - **AES-256-GCM** for encrypting secret values
 - **Argon2id** for deriving encryption keys from your master password
 
-## Option D+ (AI Security)
+## AI-Safe Access (AI Security)
 
 When using secretctl with AI agents (MCP), secrets are never exposed in plaintext:
 
@@ -35,4 +35,4 @@ When using secretctl with AI agents (MCP), secrets are never exposed in plaintex
 - `secret_get_masked`: Returns masked values like `****WXYZ`
 - No `secret_get` for plaintext via MCP
 
-[Learn more about Option D+ →](/docs/guides/mcp/security-model)
+[Learn more about AI-Safe Access →](/docs/guides/mcp/security-model)

--- a/website/docs/getting-started/for-developers.md
+++ b/website/docs/getting-started/for-developers.md
@@ -120,7 +120,7 @@ Once configured, Claude Code can:
 - Modify or delete secrets
 - Export your vault
 
-This is the **Option D+** security model - AI agents can use your secrets without ever seeing them.
+This is the **AI-Safe Access** security model - AI agents can use your secrets without ever seeing them.
 
 ## Step 6: Run Commands with Secrets
 
@@ -172,7 +172,7 @@ secretctl restore ~/backup/secrets-20241224.enc --dry-run
 
 ## Next Steps
 
-- [MCP Security Model](/docs/guides/mcp/security-model) - Understand how Option D+ keeps your secrets safe
+- [MCP Security Model](/docs/guides/mcp/security-model) - Understand how AI-Safe Access keeps your secrets safe
 - [Available MCP Tools](/docs/guides/mcp/available-tools) - Complete MCP tool reference
 - [Environment Aliases](/docs/guides/mcp/env-aliases) - Manage dev/staging/prod environments
 - [CLI Reference](/docs/reference/cli-commands) - Full CLI command documentation

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -58,7 +58,7 @@ sidebar_position: 1
 ## Why secretctl?
 
 - **Local-first**: Your secrets never leave your machine
-- **AI-ready**: Built-in MCP server with Option D+ security (AI agents never see plaintext)
+- **AI-ready**: Built-in MCP server with AI-Safe Access (AI agents never see plaintext)
 - **Simple**: Single binary, no server required
 - **Secure**: AES-256-GCM encryption with Argon2id key derivation
 

--- a/website/docs/guides/mcp/available-tools.md
+++ b/website/docs/guides/mcp/available-tools.md
@@ -199,7 +199,7 @@ List all field names and metadata for a multi-field secret. Does **not** return 
 
 ## secret_get_field
 
-Get a specific field value from a multi-field secret. **Only non-sensitive fields can be retrieved** (Option D+ policy). Sensitive fields will be rejected.
+Get a specific field value from a multi-field secret. **Only non-sensitive fields can be retrieved** (AI-Safe Access policy). Sensitive fields will be rejected.
 
 **Input Schema:**
 
@@ -225,7 +225,7 @@ Get a specific field value from a multi-field secret. **Only non-sensitive field
 
 ```json
 {
-  "error": "field 'password' is marked as sensitive (Option D+ policy)"
+  "error": "field 'password' is marked as sensitive and cannot be retrieved via MCP (AI-Safe Access policy)"
 }
 ```
 

--- a/website/docs/guides/mcp/index.md
+++ b/website/docs/guides/mcp/index.md
@@ -10,7 +10,7 @@ secretctl includes a built-in MCP (Model Context Protocol) server for secure int
 
 ## Overview
 
-The MCP server enables AI assistants to work with your secrets **without ever seeing the actual secret values**. This is achieved through the [Option D+ security model](/docs/guides/mcp/security-model).
+The MCP server enables AI assistants to work with your secrets **without ever seeing the actual secret values**. This is achieved through the [AI-Safe Access security model](/docs/guides/mcp/security-model).
 
 ## Quick Start
 
@@ -59,7 +59,7 @@ See [Claude Code Setup](/docs/guides/mcp/claude-code-setup) for detailed configu
 
 ## Learn More
 
-- [Security Model (Option D+)](/docs/guides/mcp/security-model) - How secrets are protected
+- [Security Model (AI-Safe Access)](/docs/guides/mcp/security-model) - How secrets are protected
 - [Claude Code Setup](/docs/guides/mcp/claude-code-setup) - Detailed setup guide
 - [Available Tools](/docs/guides/mcp/available-tools) - MCP tools reference
 - [Environment Aliases](/docs/guides/mcp/env-aliases) - Multi-environment configuration

--- a/website/docs/guides/mcp/security-model.md
+++ b/website/docs/guides/mcp/security-model.md
@@ -1,10 +1,10 @@
 ---
 title: Security Model
-description: How Option D+ keeps secrets safe from AI agents.
+description: How AI-Safe Access keeps secrets safe from AI agents.
 sidebar_position: 2
 ---
 
-# Security Model (Option D+)
+# Security Model (AI-Safe Access)
 
 secretctl follows the "Access Without Exposure" principle, ensuring AI agents can use your secrets without ever seeing them.
 
@@ -112,7 +112,7 @@ Output sanitization uses exact string matching. It does **not** detect:
 
 ## Threat Categories
 
-secretctl's Option D+ design protects against these threat categories:
+secretctl's AI-Safe Access design protects against these threat categories:
 
 ### 1. Direct Secret Exposure
 

--- a/website/docs/help/faq.md
+++ b/website/docs/help/faq.md
@@ -35,7 +35,7 @@ secretctl uses:
 
 ### Why can't I get plaintext secrets via MCP?
 
-This is intentional. The MCP server follows the "Option D+" security model where AI agents never receive plaintext secrets. Instead:
+This is intentional. The MCP server follows the "AI-Safe Access" security model where AI agents never receive plaintext secrets. Instead:
 - `secret_run` injects secrets as environment variables
 - `secret_get_masked` returns masked values (e.g., `****WXYZ`)
 - Output is sanitized to prevent accidental secret exposure

--- a/website/docs/reference/mcp-tools.md
+++ b/website/docs/reference/mcp-tools.md
@@ -10,7 +10,7 @@ Complete API reference for all MCP tools provided by the secretctl MCP server.
 
 ## Overview
 
-The secretctl MCP server implements a security-first design where **AI agents never receive plaintext secrets**. This follows the "Option D+" architecture, aligned with 1Password's "Access Without Exposure" philosophy.
+The secretctl MCP server implements a security-first design where **AI agents never receive plaintext secrets**. This follows the "AI-Safe Access" architecture, aligned with 1Password's "Access Without Exposure" philosophy.
 
 **Available Tools:**
 
@@ -588,7 +588,7 @@ List all field names and metadata for a multi-field secret. Returns field names,
 
 ## secret_get_field
 
-Get a specific field value from a multi-field secret. Only non-sensitive fields can be retrieved (Option D+ policy). Sensitive fields will be rejected.
+Get a specific field value from a multi-field secret. Only non-sensitive fields can be retrieved (AI-Safe Access policy). Sensitive fields will be rejected.
 
 ### Input Schema
 
@@ -646,7 +646,7 @@ Get a specific field value from a multi-field secret. Only non-sensitive fields 
 
 // Error Response
 {
-  "error": "field 'password' is marked as sensitive (Option D+ policy)"
+  "error": "field 'password' is marked as sensitive and cannot be retrieved via MCP (AI-Safe Access policy)"
 }
 ```
 
@@ -777,9 +777,9 @@ The policy file must meet these requirements:
 
 ## Security Design
 
-### Option D+ Architecture
+### AI-Safe Access Architecture
 
-The secretctl MCP server follows the "Option D+" security model:
+The secretctl MCP server follows the "AI-Safe Access" security model:
 
 | Tool | Plaintext Access | Purpose |
 |------|-----------------|---------|

--- a/website/docs/security/encryption.md
+++ b/website/docs/security/encryption.md
@@ -333,7 +333,7 @@ type SecretMetadata struct {
 
 ### MCP Access Restrictions
 
-Option D+ extends to metadata:
+AI-Safe Access extends to metadata:
 
 | Data | MCP Access |
 |------|------------|

--- a/website/docs/security/how-it-works.md
+++ b/website/docs/security/how-it-works.md
@@ -19,7 +19,7 @@ This guide explains the security architecture of secretctl, including how secret
 │   ═══════════════              ═════════                            │
 │   CLI / Desktop App            MCP Server                           │
 │        │                            │                               │
-│        │ Full Access                │ Restricted (Option D+)        │
+│        │ Full Access                │ Restricted (AI-Safe Access)   │
 │        │                            │                               │
 │        └──────────┬────────────────┘                               │
 │                   │                                                 │
@@ -151,20 +151,20 @@ secretctl restricts functionality based on access method:
 - AI agents are **proxies** that don't need to know the actual values
 - AI only needs the **result** of using secrets, not the secrets themselves
 
-## Option D+: Access Without Exposure
+## AI-Safe Access: Access Without Exposure
 
 The core security model for AI integration:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Option D+: Access Without Exposure                                  │
+│  AI-Safe Access: Access Without Exposure                            │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                                                     │
 │  ❌ Traditional MCP Implementation:                                  │
 │     AI → MCP Server → Plaintext Secret → AI → Use                   │
 │     Problem: AI "knows" the secret                                  │
 │                                                                     │
-│  ✅ secretctl Option D+:                                            │
+│  ✅ secretctl AI-Safe Access:                                       │
 │     AI → "Run this command with this secret"                        │
 │        → Secret injected directly (AI never sees it)                │
 │        → Only the result returns to AI                              │

--- a/website/docs/security/index.md
+++ b/website/docs/security/index.md
@@ -18,7 +18,7 @@ secretctl uses only Go standard library and `golang.org/x/crypto` for cryptograp
 - **Minimal dependencies** - Reduces supply chain attack surface
 - **Auditable codebase** - Easier security reviews
 
-### 2. Option D+ for AI Integration
+### 2. AI-Safe Access for AI Integration
 
 The cornerstone of secretctl's AI security model:
 
@@ -115,7 +115,7 @@ Go's garbage collector manages memory, making guaranteed zeroing difficult. This
 | HashiCorp Vault | Yes (experimental) | Yes (`read_secret`) | No (server required) | BSL |
 | Infisical | Yes | Yes (`get-secret`) | No (server required) | Yes |
 | 1Password | No (refuses MCP) | No (policy) | No (subscription) | No |
-| **secretctl** | **Yes** | **No (Option D+)** | **Yes** | **Yes** |
+| **secretctl** | **Yes** | **No (AI-Safe Access)** | **Yes** | **Yes** |
 
 **Unique Position**: secretctl is the only solution with MCP support + no plaintext to AI + fully local + open source.
 
@@ -127,7 +127,7 @@ secretctl follows the same principles that guide 1Password's approach to AI:
 |-----------|-----------|-----------|
 | Secrets stay secret | Zero-knowledge encryption | AES-256-GCM + Argon2id |
 | Deterministic authorization | LLMs don't make auth decisions | Policy engine controls access |
-| No raw credentials to LLMs | Don't include secrets in prompts | Option D+ prohibits plaintext |
+| No raw credentials to LLMs | Don't include secrets in prompts | AI-Safe Access prohibits plaintext |
 | Auditability | Record access and actions | Full audit logging |
 | Transparency | Disclose what AI sees | Only masked values returned |
 | Least privilege | Minimum necessary access | Policy-based key restrictions |

--- a/website/docs/use-cases/ai-agent-integration.md
+++ b/website/docs/use-cases/ai-agent-integration.md
@@ -26,7 +26,7 @@ Exposing raw secrets to AI agents creates risks:
 - **Logging exposure** - Secrets may appear in conversation logs
 - **No revocation** - Hard to invalidate exposed credentials
 
-### secretctl's Solution: Option D+
+### secretctl's Solution: AI-Safe Access
 
 secretctl follows the "Access Without Exposure" principle:
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -57,7 +57,7 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         Built-in MCP server for secure AI agent integration. Use with Claude Code
-        and other AI tools while keeping your secrets safe with Option D+.
+        and other AI tools while keeping your secrets safe with AI-Safe Access.
       </>
     ),
   },


### PR DESCRIPTION
## Summary

Replace internal design terminology "Option D+" with "AI-Safe Access" throughout the codebase to align with industry-standard terminology like 1Password's "Access Without Exposure" philosophy.

## Changes

- Update source code comments and error messages in `internal/mcp/*.go`
- Add AI-Safe Access section to README.md with Mermaid diagram explaining the security model
- Update all website documentation to use consistent terminology
- Update CHANGELOG.md, CI workflows, and smoke test scripts
- Fix error message consistency between code and documentation

## Why This Change?

The term "AI-Safe Access" better communicates the security model to users:
- **Clear meaning**: AI agents can utilize secrets without ever receiving plaintext values
- **Industry alignment**: Matches terminology used by 1Password ("Access Without Exposure") and HashiCorp Vault
- **User-friendly**: More intuitive than the internal codename "Option D+"

## Files Changed (23 files)

### Source Code
- `internal/mcp/server.go` - Package comment
- `internal/mcp/tools.go` - Comments and error messages
- `internal/mcp/server_test.go` - Test assertions
- `pkg/vault/migration.go` - Migration comments

### Documentation
- `README.md` - New AI-Safe Access section with Mermaid diagram
- `CHANGELOG.md` - Release notes
- Website docs (14 files) - Consistent terminology

### CI/Scripts
- `.github/workflows/release.yml` - CI check names
- `scripts/smoke-test-cli.sh` - Test descriptions

## Test Plan

- [x] Verify no remaining "Option D+" references in committed files
- [x] Error messages in docs match source code
- [x] Mermaid diagram renders correctly
- [x] Website builds successfully (local test)