### PR TITLE
feat(desktop): apply blue color theme

### DIFF
--- a/desktop/frontend/src/index.css
+++ b/desktop/frontend/src/index.css
@@ -6,15 +6,15 @@
   --color-muted: #f5f5f5;
   --color-muted-foreground: #737373;
   --color-border: #e5e5e5;
-  --color-primary: #171717;
-  --color-primary-foreground: #fafafa;
-  --color-secondary: #f5f5f5;
-  --color-secondary-foreground: #171717;
+  --color-primary: #2563eb;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #eff6ff;
+  --color-secondary-foreground: #1e40af;
   --color-destructive: #ef4444;
   --color-destructive-foreground: #fafafa;
-  --color-accent: #f5f5f5;
-  --color-accent-foreground: #171717;
-  --color-ring: #171717;
+  --color-accent: #dbeafe;
+  --color-accent-foreground: #1e40af;
+  --color-ring: #3b82f6;
   --radius: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Apply blue color theme to desktop app for a more modern appearance
- Align with security app conventions (1Password, Bitwarden)

## Changes
| Element | Before | After |
|---------|--------|-------|
| Primary | `#171717` (black) | `#2563eb` (Blue-600) |
| Secondary | `#f5f5f5` (gray) | `#eff6ff` (Blue-50) |
| Accent | `#f5f5f5` (gray) | `#dbeafe` (Blue-100) |
| Ring/Focus | `#171717` (black) | `#3b82f6` (Blue-500) |

## How to customize colors
Edit `desktop/frontend/src/index.css` `@theme` section:
```css
@theme {
  --color-primary: #2563eb;  /* Change this for different theme */
  ...
}
```

## Test plan
- [x] Build desktop app with `wails build`
- [x] Verify buttons and interactive elements show blue color
- [x] Verify focus states use blue ring