### PR TITLE
docs: update CHANGELOG for v0.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2025-12-31
+
 ### Added
 - **Textarea Field Support** - Multi-line input for SSH keys, certificates, and other large text values
   - New `inputType` field attribute: `"text"` (default) or `"textarea"`
   - SSH template's `private_key` field now uses textarea input
   - Desktop App: Textarea component with proper masking for sensitive fields
   - CLI: Multi-line input support when `inputType` is `"textarea"`
+- **Documentation** - Multi-Field Secrets section in Desktop Guide, SSH key instructions
 
 ## [0.7.0] - 2025-12-30
 
@@ -184,7 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, lock, unlock, set, get, list, delete
 - Audit commands: list, verify
 
-[Unreleased]: https://github.com/forest6511/secretctl/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/forest6511/secretctl/compare/v0.8.4...HEAD
+[0.8.4]: https://github.com/forest6511/secretctl/compare/v0.7.0...v0.8.4
 [0.7.0]: https://github.com/forest6511/secretctl/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/forest6511/secretctl/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/forest6511/secretctl/compare/v0.4.1...v0.5.0


### PR DESCRIPTION
## Summary
- Move Textarea Field Support from Unreleased to v0.8.4
- Add Documentation entry
- Update version links

**Related**: v0.8.4 release