### PR TITLE
Fix MCP server version drift (0.6.0 → 0.8.7)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -85,7 +85,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "secretctl",
-			Version: "0.6.0",
+			Version: "0.8.7",
 		},
 		nil,
 	)


### PR DESCRIPTION
## Summary
- Update MCP server version from 0.6.0 to 0.8.7 to match CHANGELOG

## Test plan
- [x] Run `.claude/scripts/doc-consistency-check.sh` - passes with 0 errors

## Verification
```
=== Documentation Consistency Check ===
1. Checking version consistency...
  ✅ Version consistent: 0.8.7
```

Fixes #152