### PR TITLE
docs(changelog): add v0.8.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8] - 2026-01-23
+
+### Added
+- **Competitor Import** - Migrate secrets from other password managers (#168)
+  - 1Password CSV export import
+  - Bitwarden JSON export import
+  - LastPass CSV export import
+  - Automatic field mapping (username, password, url, notes)
+  - Support for `--preserve-case` and `--tag` options
+- **Folder Organization** - Organize secrets into hierarchical folders (#167)
+  - CLI commands: `folder create`, `folder list`, `folder delete`, `folder rename`, `folder move`, `folder info`
+  - MCP tools: `folder_list`, `folder_create`, `folder_move_secret`
+  - Folder customization with icons and colors
+  - Path-based secret organization (e.g., `work/aws/api-key`)
+
+### Fixed
+- MCP server version string updated from hardcoded 0.6.0 to match release version (#173)
+
 ## [0.8.7] - 2026-01-22
 
 ### Added

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -85,7 +85,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    "secretctl",
-			Version: "0.8.7",
+			Version: "0.8.8",
 		},
 		nil,
 	)


### PR DESCRIPTION
## Summary
- Add v0.8.8 release notes to CHANGELOG.md
- Update MCP server version to 0.8.8

## Changes in v0.8.8
- **Competitor Import**: 1Password CSV, Bitwarden JSON, LastPass CSV (#168)
- **Folder Organization**: CLI and MCP tools for organizing secrets (#167)
- **MCP Version Fix**: Version string now matches release (#173)

## Test plan
- [x] Lint passes
- [x] Codex review completed