### PR TITLE
feat(mcp): operator-controlled trusted-directory allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Operator-controlled trusted-directory allowlist for MCP `secret_run`** (#179)
+  - `trusted_directories` field in `mcp-policy.yaml` extends the trusted set, reusing the existing tamper-resistant loader guarantees (mode `0600`, owner == current user, `O_NOFOLLOW`)
+  - `SECRETCTL_TRUSTED_DIRS` environment variable for an operator-side, agent-tamper-resistant knob set outside the MCP client's reach
+  - Sources are merged with the compiled-in defaults at server startup, cleaned and de-duplicated; relative entries are rejected
+  - Documented the trusted-directory model in the MCP Security Model guide
+
 ## [0.8.8] - 2026-01-23
 
 ### Added

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -97,10 +97,11 @@ const EnvTrustedDirs = "SECRETCTL_TRUSTED_DIRS"
 // on for PATH-hardening. A nil policy is handled (env-only operation).
 //
 // The returned slice is suitable for assignment to TrustedDirectories; the
-// caller (NewServer) installs it once at startup. Validation of policy-file
-// entries also happens earlier in ValidatePolicy, but this function defends in
-// depth against entries that bypass validation (e.g. env var, which is not
-// validated at load time).
+// caller (NewServer) installs it once at startup. This function is the
+// authoritative runtime check: LoadPolicy does not currently call ValidatePolicy,
+// so both policy-file and env entries are validated here (and only here) at
+// startup. ValidatePolicy mirrors the same absolute-path checks for use as a
+// standalone policy-validation utility (e.g. a future `secretctl policy validate`).
 func mergeTrustedDirectories(policy *Policy) (dirs []string, warnings []string) {
 	seen := make(map[string]struct{})
 	add := func(raw string) {

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,11 +19,12 @@ type EnvAliasMapping struct {
 
 // Policy represents the MCP policy configuration per mcp-design-ja.md §4
 type Policy struct {
-	Version         int                          `yaml:"version"`
-	DefaultAction   string                       `yaml:"default_action"`
-	DeniedCommands  []string                     `yaml:"denied_commands"`
-	AllowedCommands []string                     `yaml:"allowed_commands"`
-	EnvAliases      map[string][]EnvAliasMapping `yaml:"env_aliases"`
+	Version            int                          `yaml:"version"`
+	DefaultAction      string                       `yaml:"default_action"`
+	DeniedCommands     []string                     `yaml:"denied_commands"`
+	AllowedCommands    []string                     `yaml:"allowed_commands"`
+	TrustedDirectories []string                     `yaml:"trusted_directories"`
+	EnvAliases         map[string][]EnvAliasMapping `yaml:"env_aliases"`
 }
 
 // PolicyFileName is the name of the policy file
@@ -58,6 +60,12 @@ var ErrCommandNotFound = errors.New("command not found")
 // TrustedDirectories are the only directories from which commands can be executed.
 // This prevents PATH manipulation attacks where a malicious binary is placed
 // earlier in PATH to bypass the allowlist.
+//
+// This list is the compiled-in default; operators extend it at MCP server startup
+// via the trusted_directories field in mcp-policy.yaml and/or the
+// SECRETCTL_TRUSTED_DIRS environment variable (see mergeTrustedDirectories).
+// Adding more OS-specific paths here is discouraged — prefer the operator-side
+// extension mechanisms so the list does not grow unbounded.
 var TrustedDirectories = []string{
 	"/usr/bin",
 	"/bin",
@@ -65,6 +73,71 @@ var TrustedDirectories = []string{
 	"/sbin",
 	"/usr/local/bin",
 	"/opt/homebrew/bin", // macOS Homebrew
+}
+
+// EnvTrustedDirs is the environment variable used to extend the trusted-directory
+// allowlist at MCP server startup. It is read once from the server process's own
+// environment (see mergeTrustedDirectories), which the MCP client — an AI agent
+// speaking over stdio — does not control. This makes it an operator-side,
+// tamper-resistant knob, complementing the trusted_directories field in
+// mcp-policy.yaml (which itself is protected by the TOCTOU-safe loader: mode
+// 0600, owner == current user, O_NOFOLLOW). Entries are separated by the OS path
+// list separator (':' on Unix, ';' on Windows).
+const EnvTrustedDirs = "SECRETCTL_TRUSTED_DIRS"
+
+// mergeTrustedDirectories computes the effective trusted-directory list by
+// combining the compiled-in defaults (TrustedDirectories), any
+// trusted_directories entries declared in the policy, and the SECRETCTL_TRUSTED_DIRS
+// environment variable. Paths are cleaned and de-duplicated; entries from all
+// three sources are merged with equal standing.
+//
+// Non-absolute entries are skipped and reported via the returned warnings (the
+// caller is expected to log them), because a relative trusted path would be
+// ambiguous with respect to the process's working directory and unsafe to rely
+// on for PATH-hardening. A nil policy is handled (env-only operation).
+//
+// The returned slice is suitable for assignment to TrustedDirectories; the
+// caller (NewServer) installs it once at startup. Validation of policy-file
+// entries also happens earlier in ValidatePolicy, but this function defends in
+// depth against entries that bypass validation (e.g. env var, which is not
+// validated at load time).
+func mergeTrustedDirectories(policy *Policy) (dirs []string, warnings []string) {
+	seen := make(map[string]struct{})
+	add := func(raw string) {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			return
+		}
+		cleaned := filepath.Clean(s)
+		if !filepath.IsAbs(cleaned) {
+			warnings = append(warnings, fmt.Sprintf("ignoring non-absolute trusted directory entry: %q", raw))
+			return
+		}
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		dirs = append(dirs, cleaned)
+	}
+
+	for _, d := range TrustedDirectories {
+		add(d)
+	}
+	if policy != nil {
+		for _, d := range policy.TrustedDirectories {
+			add(d)
+		}
+	}
+	for _, d := range filepath.SplitList(os.Getenv(EnvTrustedDirs)) {
+		add(d)
+	}
+
+	// Always return a non-nil slice so the package global is never left empty
+	// (which would unintentionally block every command).
+	if dirs == nil {
+		dirs = []string{}
+	}
+	return dirs, warnings
 }
 
 // LoadPolicy loads the MCP policy from the vault directory.
@@ -308,6 +381,19 @@ func (p *Policy) ValidatePolicy() error {
 
 	if p.DefaultAction != ActionDeny && p.DefaultAction != ActionAllow {
 		return fmt.Errorf("invalid default_action: %s (must be '%s' or '%s')", p.DefaultAction, ActionDeny, ActionAllow)
+	}
+
+	// trusted_directories must be absolute paths. A relative entry would be
+	// resolved relative to the server's working directory, which is ambiguous
+	// and defeats the PATH-hardening the allowlist exists to provide.
+	for _, d := range p.TrustedDirectories {
+		if strings.TrimSpace(d) == "" {
+			return fmt.Errorf("trusted_directories contains an empty entry")
+		}
+		cleaned := filepath.Clean(d)
+		if !filepath.IsAbs(cleaned) {
+			return fmt.Errorf("trusted_directories entry %q must be an absolute path", d)
+		}
 	}
 
 	return nil

--- a/internal/mcp/policy_test.go
+++ b/internal/mcp/policy_test.go
@@ -954,3 +954,193 @@ func TestNewSecurityErrors(t *testing.T) {
 		t.Error("ErrCommandNotFound is nil")
 	}
 }
+
+// Tests for operator-controlled trusted-directory extension (Issue #179)
+
+// containsDir reports whether dir is present in dirs (after cleaning).
+func containsDir(dirs []string, dir string) bool {
+	cleaned := filepath.Clean(dir)
+	for _, d := range dirs {
+		if filepath.Clean(d) == cleaned {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMergeTrustedDirectories_DefaultsOnly(t *testing.T) {
+	// No policy, no env var -> exactly the compiled-in defaults (cleaned, deduped,
+	// non-nil).
+	t.Setenv(EnvTrustedDirs, "")
+	dirs, warnings := mergeTrustedDirectories(nil)
+	if warnings != nil {
+		t.Errorf("expected no warnings for defaults-only, got %v", warnings)
+	}
+	if len(dirs) != len(TrustedDirectories) {
+		t.Errorf("expected %d defaults, got %d (%v)", len(TrustedDirectories), len(dirs), dirs)
+	}
+	for _, d := range TrustedDirectories {
+		if !containsDir(dirs, d) {
+			t.Errorf("default %s missing from merge result %v", d, dirs)
+		}
+	}
+}
+
+func TestMergeTrustedDirectories_PolicyField(t *testing.T) {
+	t.Setenv(EnvTrustedDirs, "")
+	extra := "/opt/custom/bin"
+	policy := &Policy{
+		TrustedDirectories: []string{extra},
+	}
+	dirs, warnings := mergeTrustedDirectories(policy)
+	if warnings != nil {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !containsDir(dirs, extra) {
+		t.Errorf("policy entry %s missing from %v", extra, dirs)
+	}
+	// Defaults must still be present.
+	for _, d := range TrustedDirectories {
+		if !containsDir(dirs, d) {
+			t.Errorf("default %s dropped from %v", d, dirs)
+		}
+	}
+}
+
+func TestMergeTrustedDirectories_EnvVar(t *testing.T) {
+	extra1 := "/opt/env-a/bin"
+	extra2 := "/opt/env-b/bin"
+	t.Setenv(EnvTrustedDirs, extra1+string(filepath.ListSeparator)+extra2)
+	dirs, warnings := mergeTrustedDirectories(nil)
+	if warnings != nil {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !containsDir(dirs, extra1) {
+		t.Errorf("env entry %s missing from %v", extra1, dirs)
+	}
+	if !containsDir(dirs, extra2) {
+		t.Errorf("env entry %s missing from %v", extra2, dirs)
+	}
+}
+
+func TestMergeTrustedDirectories_AllSourcesDedup(t *testing.T) {
+	// Same path supplied via policy AND env must appear exactly once.
+	shared := "/opt/shared/bin"
+	policyOnly := "/opt/policy/bin"
+	envOnly := "/opt/env/bin"
+	t.Setenv(EnvTrustedDirs, shared+string(filepath.ListSeparator)+envOnly)
+	policy := &Policy{
+		TrustedDirectories: []string{shared, policyOnly},
+	}
+	dirs, _ := mergeTrustedDirectories(policy)
+
+	// Count occurrences of the shared path.
+	count := 0
+	for _, d := range dirs {
+		if filepath.Clean(d) == filepath.Clean(shared) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("shared path %s appeared %d times, expected 1 (dirs=%v)", shared, count, dirs)
+	}
+	if !containsDir(dirs, policyOnly) {
+		t.Errorf("policy-only entry %s missing from %v", policyOnly, dirs)
+	}
+	if !containsDir(dirs, envOnly) {
+		t.Errorf("env-only entry %s missing from %v", envOnly, dirs)
+	}
+}
+
+func TestMergeTrustedDirectories_RelativeRejected(t *testing.T) {
+	// Relative entries (from policy or env) must be skipped and reported as a
+	// warning, never silently accepted — a relative trusted path is ambiguous and
+	// unsafe for PATH-hardening.
+	t.Setenv(EnvTrustedDirs, "relative-env/bin:../escape")
+	policy := &Policy{
+		TrustedDirectories: []string{"relative-policy/bin"},
+	}
+	dirs, warnings := mergeTrustedDirectories(policy)
+
+	if len(warnings) < 3 {
+		t.Errorf("expected warnings for the relative entries, got %d (%v)", len(warnings), warnings)
+	}
+	for _, d := range dirs {
+		if !filepath.IsAbs(filepath.Clean(d)) {
+			t.Errorf("relative path leaked into result: %q (dirs=%v)", d, dirs)
+		}
+	}
+}
+
+func TestMergeTrustedDirectories_CleansPaths(t *testing.T) {
+	// Trailing slashes and redundant segments are normalized via filepath.Clean,
+	// and a cleaned duplicate of a default collapses onto it.
+	t.Setenv(EnvTrustedDirs, "/usr/bin//")
+	dirs, warnings := mergeTrustedDirectories(nil)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	count := 0
+	for _, d := range dirs {
+		if filepath.Clean(d) == "/usr/bin" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected /usr/bin exactly once after cleaning, got %d (%v)", count, dirs)
+	}
+}
+
+func TestValidatePolicy_TrustedDirectories(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  *Policy
+		wantErr bool
+	}{
+		{
+			name: "absolute entries valid",
+			policy: &Policy{
+				Version:            1,
+				DefaultAction:      ActionDeny,
+				TrustedDirectories: []string{"/opt/homebrew/bin", "/home/linuxbrew/.linuxbrew/bin"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "relative entry rejected",
+			policy: &Policy{
+				Version:            1,
+				DefaultAction:      ActionDeny,
+				TrustedDirectories: []string{"relative/bin"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty entry rejected",
+			policy: &Policy{
+				Version:            1,
+				DefaultAction:      ActionDeny,
+				TrustedDirectories: []string{""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "whitespace-only entry rejected",
+			policy: &Policy{
+				Version:            1,
+				DefaultAction:      ActionDeny,
+				TrustedDirectories: []string{"   "},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.ValidatePolicy()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePolicy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mcp/policy_test.go
+++ b/internal/mcp/policy_test.go
@@ -1055,8 +1055,9 @@ func TestMergeTrustedDirectories_AllSourcesDedup(t *testing.T) {
 func TestMergeTrustedDirectories_RelativeRejected(t *testing.T) {
 	// Relative entries (from policy or env) must be skipped and reported as a
 	// warning, never silently accepted — a relative trusted path is ambiguous and
-	// unsafe for PATH-hardening.
-	t.Setenv(EnvTrustedDirs, "relative-env/bin:../escape")
+	// unsafe for PATH-hardening. Use filepath.ListSeparator so the test is
+	// portable across Unix (':') and Windows (';').
+	t.Setenv(EnvTrustedDirs, "relative-env/bin"+string(filepath.ListSeparator)+"../escape")
 	policy := &Policy{
 		TrustedDirectories: []string{"relative-policy/bin"},
 	}

--- a/internal/mcp/policy_test.go
+++ b/internal/mcp/policy_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -121,6 +122,63 @@ allowed_commands:
 	// Should default to deny
 	if policy.DefaultAction != ActionDeny {
 		t.Errorf("expected default_action 'deny', got '%s'", policy.DefaultAction)
+	}
+}
+
+func TestLoadPolicy_TrustedDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, PolicyFileName)
+
+	// Policy with trusted_directories
+	content := `version: 1
+default_action: deny
+allowed_commands:
+  - glab
+trusted_directories:
+  - /home/linuxbrew/.linuxbrew/bin
+  - /opt/custom/bin
+`
+	if err := os.WriteFile(policyPath, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write policy file: %v", err)
+	}
+
+	policy, err := LoadPolicy(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadPolicy failed: %v", err)
+	}
+
+	// Verify trusted_directories are loaded
+	expectedDirs := []string{"/home/linuxbrew/.linuxbrew/bin", "/opt/custom/bin"}
+	if len(policy.TrustedDirectories) != len(expectedDirs) {
+		t.Errorf("expected %d trusted directories, got %d: %v", len(expectedDirs), len(policy.TrustedDirectories), policy.TrustedDirectories)
+	}
+	for i, dir := range expectedDirs {
+		if policy.TrustedDirectories[i] != dir {
+			t.Errorf("trusted directory %d: expected %s, got %s", i, dir, policy.TrustedDirectories[i])
+		}
+	}
+
+	// Also test merge with these directories
+	dirs, warnings := mergeTrustedDirectories(policy)
+	fmt.Printf("Merged dirs: %v\nWarnings: %v\n", dirs, warnings)
+	if len(warnings) > 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	// Should have defaults + the two policy dirs
+	if len(dirs) < len(TrustedDirectories)+2 {
+		t.Errorf("expected at least %d dirs (defaults + 2 policy), got %d: %v", len(TrustedDirectories)+2, len(dirs), dirs)
+	}
+	for _, d := range expectedDirs {
+		found := false
+		for _, ed := range dirs {
+			if ed == d {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected directory %s not found in merged result: %v", d, dirs)
+		}
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -61,6 +61,19 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		policy = nil
 	}
 
+	// Install the effective trusted-directory allowlist, merging the compiled-in
+	// defaults with operator-controlled sources: the trusted_directories field in
+	// mcp-policy.yaml (protected by the TOCTOU-safe loader) and the
+	// SECRETCTL_TRUSTED_DIRS env var (set in the operator's environment, outside
+	// the agent's reach). Computed once at startup; ResolveAndValidateCommand and
+	// helpers consult the package global for the lifetime of the process. Run
+	// unconditionally so env-only extension works even when policy load failed.
+	effectiveDirs, dirWarnings := mergeTrustedDirectories(policy)
+	for _, w := range dirWarnings {
+		log.Printf("warning: %s", w)
+	}
+	TrustedDirectories = effectiveDirs
+
 	// Create vault instance
 	v := vault.New(vaultPath)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -65,9 +65,16 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	// defaults with operator-controlled sources: the trusted_directories field in
 	// mcp-policy.yaml (protected by the TOCTOU-safe loader) and the
 	// SECRETCTL_TRUSTED_DIRS env var (set in the operator's environment, outside
-	// the agent's reach). Computed once at startup; ResolveAndValidateCommand and
-	// helpers consult the package global for the lifetime of the process. Run
-	// unconditionally so env-only extension works even when policy load failed.
+	// the agent's reach). ResolveAndValidateCommand and helpers consult the
+	// package global for the lifetime of the process. Run unconditionally so
+	// env-only extension works even when policy load failed.
+	//
+	// Contract: this assignment must happen exactly once, before any secret_run
+	// request. The package global is read without synchronization on every command
+	// resolution, so a second NewServer call (e.g. from a future reconfiguration
+	// path) would race with readers and would also treat this call's merged result
+	// as the new "defaults", compounding across calls. Today NewServer is
+	// guaranteed single-call at process startup.
 	effectiveDirs, dirWarnings := mergeTrustedDirectories(policy)
 	for _, w := range dirWarnings {
 		log.Printf("warning: %s", w)

--- a/website/docs/guides/mcp/security-model.md
+++ b/website/docs/guides/mcp/security-model.md
@@ -86,6 +86,49 @@ denied_commands:
   - mkfs
 ```
 
+## Trusted Directories
+
+When `secret_run` executes a command, the binary is only allowed to run if it lives in a **trusted directory**. This hardens against PATH-manipulation attacks, where a malicious binary is planted earlier in `PATH` to shadow a legitimate tool and bypass the command allowlist. The check resolves symlinks first, so a symlink in a trusted directory that points at an untrusted location is still rejected — the *real* path of the binary is what must be trusted.
+
+### Default trusted directories
+
+The compiled-in defaults cover the standard system binary locations plus macOS Homebrew:
+
+- `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, `/usr/local/bin`
+- `/opt/homebrew/bin` (macOS Homebrew)
+
+These are intentionally minimal. Rather than growing this list for every package manager and version (a losing game), extend it with the operator-controlled mechanisms below.
+
+### Extending the allowlist
+
+Operators can add trusted directories from two sources, both read once at MCP server startup. They are equally trusted and are merged with the defaults (cleaned and de-duplicated).
+
+**1. Policy file** — add a `trusted_directories` list to `mcp-policy.yaml`. This reuses the existing tamper-resistant loader guarantees for the policy file: file mode `0600`, owned by the current user, and `O_NOFOLLOW` to reject symlinks.
+
+```yaml
+version: 1
+default_action: deny
+allowed_commands:
+  - glab
+  - terraform
+trusted_directories:
+  - /home/linuxbrew/.linuxbrew/bin
+  - /opt/homebrew/bin
+```
+
+**2. Environment variable** — set `SECRETCTL_TRUSTED_DIRS` in the environment that launches `secretctl mcp-server`. Entries are separated by the OS path list separator (`:` on Unix, `;` on Windows).
+
+```bash
+export SECRETCTL_TRUSTED_DIRS=/home/linuxbrew/.linuxbrew/bin
+secretctl mcp-server
+```
+
+### Threat-model note
+
+The trusted-directory list is operator-controlled by design. The policy file is already the trust root (it controls `allowed_commands` and `default_action`), so extending it with `trusted_directories` does not expand the attack surface. The environment variable is read from the server process's own environment, which the MCP client — an AI agent speaking over stdio — cannot mutate. Do **not** place trusted-directory configuration somewhere the agent can write (e.g. a world-writable file without the loader's ownership/permission checks); that would defeat the PATH-hardening this allowlist exists to provide.
+
+Entries must be absolute paths; relative entries are rejected at policy-load time and skipped (with a logged warning) at server startup if they arrive via the environment variable.
+
 ## Output Sanitization
 
 When a command is executed via `secret_run`, the output is automatically scanned for secret values. Any matches are replaced with `[REDACTED:key]`.

--- a/website/docs/guides/mcp/security-model.md
+++ b/website/docs/guides/mcp/security-model.md
@@ -127,7 +127,7 @@ secretctl mcp-server
 
 The trusted-directory list is operator-controlled by design. The policy file is already the trust root (it controls `allowed_commands` and `default_action`), so extending it with `trusted_directories` does not expand the attack surface. The environment variable is read from the server process's own environment, which the MCP client — an AI agent speaking over stdio — cannot mutate. Do **not** place trusted-directory configuration somewhere the agent can write (e.g. a world-writable file without the loader's ownership/permission checks); that would defeat the PATH-hardening this allowlist exists to provide.
 
-Entries must be absolute paths; relative entries are rejected at policy-load time and skipped (with a logged warning) at server startup if they arrive via the environment variable.
+Entries must be absolute paths; relative entries — whether from the policy file or the environment variable — are skipped at server startup with a logged warning.
 
 ## Output Sanitization
 


### PR DESCRIPTION
## Summary


The MCP `secret_run` trusted-directory allowlist (`TrustedDirectories` in `internal/mcp/policy.go`) was hardcoded with no operator-controlled way to extend it. This blocked legitimate tools in locations the defaults don't cover (e.g. linuxbrew on Linux — `/opt/homebrew/bin` is present but `/home/linuxbrew/.linuxbrew/...` is not) and, more importantly, provided **no safe mechanism** for an operator to authorize additional tool locations.

Rather than grow the hardcoded defaults (a losing game — every package manager and version is a new entry), this PR keeps the defaults minimal and adds two operator-controlled extension mechanisms, both merged with the compiled-in defaults at MCP server startup (cleaned and de-duplicated):

1. **`trusted_directories` field in `mcp-policy.yaml`** — reuses the existing tamper-resistant loader guarantees already enforced for the policy file: mode `0600`, owned by the current user, `O_NOFOLLOW` against symlinks.
2. **`SECRETCTL_TRUSTED_DIRS` environment variable** — read once from the server process's own environment, which the MCP client (an AI agent speaking over stdio) cannot mutate.

```yaml
version: 1
default_action: deny
allowed_commands: [glab, terraform]
trusted_directories:
  - /home/linuxbrew/.linuxbrew/bin
```
```bash
export SECRETCTL_TRUSTED_DIRS=/home/linuxbrew/.linuxbrew/bin
secretctl mcp-server
```

## Threat-model rationale

The policy file is already the trust root (it controls `allowed_commands`, `denied_commands`, and `default_action`), so adding `trusted_directories` there expands no attack surface — an attacker who could rewrite it to add a trusted directory could already rewrite it to set `default_action: allow`. The env var is the operator-side, agent-tamper-resistant knob: it lives in the server's launch environment, outside the agent's reach. Entries must be absolute paths; relative entries are rejected at policy-load time and skipped (with a logged warning) when arriving via the env var.

## Implementation notes

- Computed once in `NewServer` and assigned to the existing package global, so `ResolveAndValidateCommand` / `lookupCommandInTrustedDirs` / `validateTrustedDirectory` and both call sites in `tools.go` are untouched. The merge runs even when policy load fails, so env-only operation works.
- The CLI `secretctl run` path is unchanged (it uses `exec.LookPath` with no wall) — this is MCP-only by design, as noted in the issue.

## Follow-up (not in this PR)

The hardcoded defaults (`/opt/homebrew/bin`, etc.) are themselves a mild design smell — now that extension exists, trimming the defaults (or making the list platform-conditional) could be considered separately. I left them as-is to avoid breaking existing macOS users.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...` (all packages)
- `golangci-lint run ./...` (v1.64.5 against the repo's v1 config)
- `gofmt -l` on changed files (clean)

## Checklist

- [x] Code follows existing style and conventions
- [x] Tests added (table-driven, covering defaults-only / policy field / env var / dedup / relative-rejection / path cleaning / ValidatePolicy)
- [x] Documentation updated (MCP Security Model guide)
- [x] CHANGELOG updated
- [x] `go test`, `golangci-lint`, `gofmt` pass