### PR TITLE
fix(desktop): pasted secrets are saved as empty strings; dark theme text invisible

### DIFF
--- a/desktop/frontend/src/components/AddFieldDialog.tsx
+++ b/desktop/frontend/src/components/AddFieldDialog.tsx
@@ -138,7 +138,7 @@ export function AddFieldDialog({
                 className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded border-2 transition-all ${
                   inputType === 'text'
                     ? 'border-sky-500 bg-sky-50 text-sky-700'
-                    : 'border-slate-200 hover:border-slate-300 text-slate-600'
+                    : 'border-border hover:border-muted-foreground text-muted-foreground'
                 }`}
                 data-testid="input-type-text"
               >
@@ -151,7 +151,7 @@ export function AddFieldDialog({
                 className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded border-2 transition-all ${
                   inputType === 'textarea'
                     ? 'border-sky-500 bg-sky-50 text-sky-700'
-                    : 'border-slate-200 hover:border-slate-300 text-slate-600'
+                    : 'border-border hover:border-muted-foreground text-muted-foreground'
                 }`}
                 data-testid="input-type-textarea"
               >

--- a/desktop/frontend/src/components/ui/button.tsx
+++ b/desktop/frontend/src/components/ui/button.tsx
@@ -9,9 +9,9 @@ const buttonVariants = cva(
       variant: {
         default: "bg-sky-500 text-white hover:bg-sky-600 active:bg-sky-700",
         destructive: "bg-red-500 text-white hover:bg-red-600 active:bg-red-700",
-        outline: "border-2 border-sky-500 text-sky-600 bg-white hover:bg-sky-50 hover:border-sky-600 active:bg-sky-100",
+        outline: "border-2 border-sky-500 text-sky-600 bg-card hover:bg-sky-50 hover:text-sky-700 hover:border-sky-600 active:bg-sky-100 active:text-sky-800",
         secondary: "bg-sky-100 text-sky-700 hover:bg-sky-200 hover:text-sky-800 active:bg-sky-300",
-        ghost: "text-slate-600 hover:bg-sky-100 hover:text-sky-700 active:bg-sky-200",
+        ghost: "text-muted-foreground hover:bg-sky-100 hover:text-sky-700 active:bg-sky-200",
         link: "text-sky-600 underline-offset-4 hover:underline hover:text-sky-700 active:text-sky-800",
       },
       size: {

--- a/desktop/frontend/src/components/ui/card.tsx
+++ b/desktop/frontend/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-lg border border-slate-200 bg-white", className)}
+      className={cn("rounded-lg border border-border bg-card text-card-foreground", className)}
       {...props}
     />
   )
@@ -21,7 +21,7 @@ CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("font-semibold leading-none tracking-tight text-slate-800", className)} {...props} />
+    <h3 ref={ref} className={cn("font-semibold leading-none tracking-tight", className)} {...props} />
   )
 )
 CardTitle.displayName = "CardTitle"

--- a/desktop/frontend/src/components/ui/input.tsx
+++ b/desktop/frontend/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded border-2 border-slate-200 bg-white px-3 py-1 text-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:border-sky-500 focus-visible:ring-2 focus-visible:ring-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-300",
+          "flex h-9 w-full rounded border-2 border-border bg-card text-card-foreground px-3 py-1 text-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:border-sky-500 focus-visible:ring-2 focus-visible:ring-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50 hover:border-muted-foreground",
           className
         )}
         ref={ref}

--- a/desktop/frontend/src/components/ui/textarea.tsx
+++ b/desktop/frontend/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[60px] w-full rounded border-2 border-slate-200 bg-white px-3 py-2 text-sm transition-all duration-200 placeholder:text-slate-400 focus-visible:outline-none focus-visible:border-sky-500 focus-visible:ring-2 focus-visible:ring-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50 hover:border-slate-300 resize-y",
+          "flex min-h-[60px] w-full rounded border-2 border-border bg-card text-card-foreground px-3 py-2 text-sm transition-all duration-200 placeholder:text-slate-400 focus-visible:outline-none focus-visible:border-sky-500 focus-visible:ring-2 focus-visible:ring-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50 hover:border-muted-foreground resize-y",
           className
         )}
         ref={ref}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -51,11 +51,18 @@ func main() {
 		runtime.Quit(app.ctx)
 	})
 
-	// Edit menu
-	editMenu := appMenu.AddSubmenu("Edit")
-	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
-	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
-	editMenu.AddText("Paste", keys.CmdOrCtrl("v"), nil)
+	// Edit menu (macOS only).
+	//
+	// Must be the role-backed menu. Declaring Cut/Copy/Paste via AddText with
+	// nil callbacks registers Cmd+X/C/V as application accelerators that
+	// consume the keystroke and then do nothing, so paste never reaches the
+	// webview and pasted secrets save as empty strings.
+	//
+	// On Windows/Linux the webview handles Ctrl+X/C/V itself, so no menu
+	// entry is needed there.
+	if goruntime.GOOS == "darwin" {
+		appMenu.Append(menu.EditMenu())
+	}
 
 	err := wails.Run(&options.App{
 		Title:     "secretctl",


### PR DESCRIPTION
## Summary

Two bugs in the desktop app that compound into silent data loss: **pasting a secret saves an empty string**, and **dark-theme text is invisible**, so there is no way to notice the first one.

Reproduced on macOS 15 (Darwin 24.3.0, arm64), built from `main` at 2de7b68 (v0.8.8).

## 1. Paste is swallowed — `desktop/main.go`

```go
editMenu := appMenu.AddSubmenu("Edit")
editMenu.AddText("Paste", keys.CmdOrCtrl("v"), nil)
```

`AddText` with a nil callback registers Cmd+V as an application accelerator that consumes the keystroke and does nothing, so paste never reaches the webview. React's `onChange` never fires, `formFields` keeps the empty string, and `CreateSecretMultiField` persists it.

Typing works, which is what makes this hard to spot — the frontend and Go paths are both correct.

| Action | Before | After |
|---|---|---|
| Type value → Save → reveal | ✅ round-trips | ✅ |
| **Paste value → Save → reveal** | ❌ **empty string stored** | ✅ round-trips |

Fixed by using the role-backed `menu.EditMenu()`, which maps to the native NSMenu actions WKWebView responds to.

The custom Cut/Copy/Paste items are dropped rather than kept behind a non-darwin branch: the nil-callback behaviour is not macOS specific, and Windows/Linux webviews handle Ctrl+X/C/V natively without a menu entry. Happy to restore a guarded branch if you would rather keep the menu visible on those platforms.

## 2. Dark theme text invisible — UI primitives

`index.css` defines a full dark palette under `[data-theme="dark"]`, but `card.tsx`, `input.tsx`, `textarea.tsx`, `button.tsx` and `AddFieldDialog.tsx` hardcode `bg-white` / `text-slate-800` / `border-slate-200` and ignore it. The result on a dark theme is near-white text on a hardcoded white card — form labels, the secret key, and the masked dots of sensitive fields all disappear.

Swapped to the tokens already defined in `index.css` (`bg-card`, `text-card-foreground`, `border-border`, `text-muted-foreground`).

`placeholder:text-slate-400` is deliberately left as-is — switching it to `text-muted-foreground` darkens placeholders in light mode (`#94a3b8` → `#475569`), close enough to real values to be confusing.

## Testing

- `vitest run` — 49 passed
- `tsc --noEmit` — clean
- `go vet ./...` — clean (two pre-existing warnings in `app.go`, untouched)
- Manual: built the `.app`, created a secret by pasting, saved, reloaded, revealed the value; confirmed labels and masked dots are legible in dark theme

## Not included

Noticed while investigating, left out to keep this focused — happy to open issues or a follow-up PR:

- The per-field copy button toasts "Copied!" even when the field is empty, since the toast reflects the call succeeding rather than there being content.
- `secrets.deleteSecretConfirmWithKey` is used at `SecretsPage.tsx:750` but is missing from both `en.json` and `ja.json`, so the delete dialog renders the raw key.
